### PR TITLE
Added headers to rpc

### DIFF
--- a/libs/filter_example/src/example_filter.rs
+++ b/libs/filter_example/src/example_filter.rs
@@ -89,6 +89,7 @@ impl Filter {
                        data: x.data,
                        uid: x.uid,
                        path: x.path.clone(),
+                       headers: x.headers.clone(),
                    });
         }
         let my_node = my_node_wrapped
@@ -176,6 +177,7 @@ impl Filter {
             data: x.data,
             uid: x.uid,
             path: x.path.clone(),
+            headers: x.headers.clone(),
         })
     }
 }
@@ -194,6 +196,7 @@ mod tests {
             data: 1,
             uid: 1,
             path: String::from("ok"),
+            headers: HashMap::new(),
         };
         my_filter.execute(&incoming_rpc);
         assert!(my_filter.filter_state.len() == 2);

--- a/libs/rpc_lib/src/rpc.rs
+++ b/libs/rpc_lib/src/rpc.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
+
 #[derive(PartialEq, Clone, Debug)]
 #[repr(C)]
 pub struct Rpc {
     pub data: u32,    // application data
     pub uid: u64,     // number of hops the message has taken
     pub path: String, // the path that the request has taken thus far
+    pub headers: HashMap<String, String>, // the "http" headers of the rpc, ie, filter-defined book keeping
 }
 
 impl Rpc {
@@ -14,6 +17,7 @@ impl Rpc {
                 data: data,
                 uid: COUNTER,
                 path: String::new(),
+                headers: HashMap::new(),
             }
         };
         unsafe {


### PR DESCRIPTION
Adding headers to rpcs;  these will be used by the filters.  This closes the issue about having custom headers.