### PR TITLE
Fix errors found while making tests

### DIFF
--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -4,6 +4,7 @@ use petgraph::algo::{dijkstra, toposort};
 use petgraph::graph::{Graph, NodeIndex};
 use std::collections::HashMap;
 
+
 /* This function creates a petgraph graph representing the query given by the user.
  * For example, if the cql query were MATCH n -> m, e WHERE ... the input to this function
  * would be vertices = [n, m], edges = [(n,m)].
@@ -114,7 +115,8 @@ pub fn generate_trace_graph_from_headers(
                 let mut values_iterator = statement.split("==");
                 let property_with_node = values_iterator.next().unwrap().clone().to_string();
                 let mut period_iterator = property_with_node.split(".");
-                let node = period_iterator.next().unwrap();
+                let mut node = period_iterator.next().unwrap().to_string();
+                node.retain(|c| !c.is_whitespace());
                 let mut property = String::new();
                 for quality in period_iterator {
                     property.push_str(&quality);
@@ -122,7 +124,7 @@ pub fn generate_trace_graph_from_headers(
                 }
                 let _ = property.pop(); // get rid of trailing period
                 let node_weight: &mut (String, HashMap<String, String>) = graph
-                    .node_weight_mut(node_str_to_node_handle[node])
+                    .node_weight_mut(node_str_to_node_handle[&node])
                     .unwrap();
                 node_weight
                     .1

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -4,7 +4,6 @@ use petgraph::algo::{dijkstra, toposort};
 use petgraph::graph::{Graph, NodeIndex};
 use std::collections::HashMap;
 
-
 /* This function creates a petgraph graph representing the query given by the user.
  * For example, if the cql query were MATCH n -> m, e WHERE ... the input to this function
  * would be vertices = [n, m], edges = [(n,m)].

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -114,7 +114,7 @@ pub fn generate_trace_graph_from_headers(
                 let mut values_iterator = statement.split("==");
                 let property_with_node = values_iterator.next().unwrap().clone().to_string();
                 let mut period_iterator = property_with_node.split(".");
-                let node = period_iterator.next().unwrap().to_string();
+                let node = period_iterator.next().unwrap();
                 let mut property = String::new();
                 for quality in period_iterator {
                     property.push_str(&quality);
@@ -122,7 +122,7 @@ pub fn generate_trace_graph_from_headers(
                 }
                 let _ = property.pop(); // get rid of trailing period
                 let node_weight: &mut (String, HashMap<String, String>) = graph
-                    .node_weight_mut(node_str_to_node_handle[&node])
+                    .node_weight_mut(node_str_to_node_handle[node])
                     .unwrap();
                 node_weight
                     .1

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -114,7 +114,7 @@ pub fn generate_trace_graph_from_headers(
                 let mut values_iterator = statement.split("==");
                 let property_with_node = values_iterator.next().unwrap().clone().to_string();
                 let mut period_iterator = property_with_node.split(".");
-                let node = period_iterator.next().unwrap();
+                let node = period_iterator.next().unwrap().to_string();
                 let mut property = String::new();
                 for quality in period_iterator {
                     property.push_str(&quality);
@@ -122,7 +122,7 @@ pub fn generate_trace_graph_from_headers(
                 }
                 let _ = property.pop(); // get rid of trailing period
                 let node_weight: &mut (String, HashMap<String, String>) = graph
-                    .node_weight_mut(node_str_to_node_handle[node])
+                    .node_weight_mut(node_str_to_node_handle[&node])
                     .unwrap();
                 node_weight
                     .1

--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -78,7 +78,7 @@ impl Edge {
             })
             .unwrap();
     }
-    pub fn dequeue(&mut self, now: u64) -> Vec<(Rpc, Option<String>, String)> {
+    pub fn dequeue(&mut self, now: u64) -> Vec<(Rpc, Option<String>)> {
         if self.queue.size() == 0 {
             return vec![];
         } else if self.queue.peek().unwrap().start_time + self.delay <= now {
@@ -95,7 +95,7 @@ impl Edge {
                 if dest == queue_element_to_remove.sender {
                     dest = self.neighbors[1].clone();
                 }
-                ret.push((queue_element_to_remove.rpc, None, dest));
+                ret.push((queue_element_to_remove.rpc, Some(dest)));
             }
             // Either the queue has emptied or no other RPCs are ready.
             assert!(

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -52,18 +52,20 @@ fn main() {
     let mut simulator: Simulator = Simulator::new(seed);
 
     // node arguments go:  id, capacity, egress_rate, generation_rate, plugin
-    simulator.add_node("traffic-gen", 10, 1, 1, plugin_str);
+    simulator.add_node("traffic-gen", 1, 1, 1, plugin_str);
     simulator.add_node("node-1", 10, 1, 0, plugin_str);
     simulator.add_node("node-2", 10, 1, 0, plugin_str);
     simulator.add_node("node-3", 10, 1, 0, plugin_str);
-    simulator.add_node("node-4", 1, 0, 0, plugin_str); // in setting egress rate to 0, we are making a sink
+    simulator.add_node("node-4", 1, 1, 0, plugin_str); // in setting egress rate to 0, we are making a sink
+    simulator.add_node("node-5", 1, 1, 0, plugin_str); // in setting egress rate to 0, we are making a sink
 
     // edge arguments go:  delay, endpoint1, endpoint2, unidirectional
     simulator.add_edge(1, "traffic-gen", "node-1", true);
     simulator.add_edge(1, "node-1", "node-2", false);
     simulator.add_edge(1, "node-1", "node-3", false);
-    //one way rpc sink
+    //one way rpc sinks
     simulator.add_edge(1, "node-1", "node-4", true);
+    simulator.add_edge(1, "node-2", "node-5", true);
 
     // Print the graph
     if let Some(_argument) = matches.value_of("print_graph") {

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -36,17 +36,17 @@ impl fmt::Display for Node {
             }
         } else {
             if self.plugin.is_none() {
-                write!(f, "Node {{ capacity : {}, egress_rate : {}, generation_rate : {}, plugin : None, id : {}, queue : {} }}",
-                       &self.capacity, &self.egress_rate, &self.generation_rate, &self.id, &self.queue.size())
+                write!(f, "Node {{ id : {}, egress_rate : {}, generation_rate : {}, plugin : None, capacity : {}, queue : {} }}",
+                       &self.id, &self.egress_rate, &self.generation_rate, &self.capacity, &self.queue.size())
             } else {
                 write!(
                     f,
-                    "Node {{ capacity : {}, egress_rate : {}, generation_rate : {}, plugin : {}, id : {}, queue : {} }}",
-                    &self.capacity,
+                    "Node {{ id : {}, egress_rate : {}, generation_rate : {}, plugin : {}, capacity : {}, queue : {} }}",
+                    &self.id,
                     &self.egress_rate,
                     &self.generation_rate,
                     self.plugin.as_ref().unwrap(),
-                    &self.id,
+                    &self.capacity,
                     &self.queue.size()
                 )
             }

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -111,7 +111,9 @@ impl Simulator {
         // tick all elements to generate Rpcs
         for (i, element) in self.elements.iter_mut() {
             let rpcs = element.tick(tick);
-            self.rpc_buffer.insert(i.to_string(), rpcs);
+            for (rpc, dst) in rpcs {
+                self.rpc_buffer.get_mut(i).unwrap().push((rpc, dst));
+            }
             println!(
                 "After tick {:5}, {:45} \n\toutputs {:?}\n",
                 tick, element, self.rpc_buffer[i]
@@ -131,7 +133,8 @@ impl Simulator {
         }
         for i in 0..self.elements.keys().count() {
             let src = &indices_to_sim_el[&i];
-            for (rpc, dst) in &self.rpc_buffer[src] {
+            while !&self.rpc_buffer[src].is_empty() {
+                let (rpc, dst) = &self.rpc_buffer.get_mut(src).unwrap().pop().unwrap();
                 if dst.is_some() {
                     // Before we send this rpc on, we should update its path to include the most recently traversed node if applicable
                     // TODO: is cloning the best way to do this?
@@ -139,7 +142,6 @@ impl Simulator {
                     if self.elements[src].whoami().0 {
                         new_rpc.add_to_path(src);
                     }
-
                     self.elements
                         .get_mut(dst.as_ref().clone().unwrap())
                         .unwrap()

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -108,6 +108,7 @@ impl Simulator {
     }
 
     pub fn tick(&mut self, tick: u64) {
+        // TODO: clean this up
         // tick all elements to generate Rpcs
         for (i, element) in self.elements.iter_mut() {
             let rpcs = element.tick(tick);


### PR DESCRIPTION
I'm making tests for the output of the simulator, and this is just a hodgepodge of errors I found while making tests.  The main ones are:
1. Changing the edge dequeue headers to only the ones that are actually used
2. Changing how we deal with properties headers and path headers in graph_utils - we do not want to split by whitespace, but rather by the comma dividing different nodes.
3. Changing how node is displayed so that ID always comes first (makes it easier to trace the output)
4. Fix a bug in the simulator wherein the simulator forgot to consume the rpcs in the rpc buffer once it had passed them on.  Before, the rpcs were before staying in the rpc buffer when they should have been consumed, which resulted in duplicate rpcs.