### PR TITLE
Refactoring

### DIFF
--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Edge {
 }
 
 impl SimElement for Edge {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, Option<String>)> {
+    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
         let ret = self.dequeue(tick);
         let mut to_return = Vec::new();
         for element in ret {
@@ -78,7 +78,7 @@ impl Edge {
             })
             .unwrap();
     }
-    pub fn dequeue(&mut self, now: u64) -> Vec<(Rpc, Option<String>)> {
+    pub fn dequeue(&mut self, now: u64) -> Vec<(Rpc, String)> {
         if self.queue.size() == 0 {
             return vec![];
         } else if self.queue.peek().unwrap().start_time + self.delay <= now {
@@ -95,7 +95,7 @@ impl Edge {
                 if dest == queue_element_to_remove.sender {
                     dest = self.neighbors[1].clone();
                 }
-                ret.push((queue_element_to_remove.rpc, Some(dest)));
+                ret.push((queue_element_to_remove.rpc, dest));
             }
             // Either the queue has emptied or no other RPCs are ready.
             assert!(

--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -63,8 +63,8 @@ impl SimElement for Edge {
         assert!(self.neighbors.len() < 2);
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (bool, &str, &Vec<String>) {
-        return (false, &self.id, &self.neighbors);
+    fn whoami(&self) -> (&str, &Vec<String>) {
+        return (&self.id, &self.neighbors);
     }
 }
 

--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -56,7 +56,7 @@ impl SimElement for Edge {
         }
         return to_return;
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str) {
+    fn recv(&mut self, rpc: &Rpc, tick: u64, sender: &str) {
         self.enqueue(rpc, tick, sender);
     }
     fn add_connection(&mut self, neighbor: String) {
@@ -69,11 +69,11 @@ impl SimElement for Edge {
 }
 
 impl Edge {
-    pub fn enqueue(&mut self, x: Rpc, now: u64, sender: &str) {
+    pub fn enqueue(&mut self, x: &Rpc, now: u64, sender: &str) {
         self.queue
             .add(TimestampedRpc {
                 start_time: now,
-                rpc: x,
+                rpc: x.clone(),
                 sender: sender.to_string(),
             })
             .unwrap();
@@ -138,7 +138,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc(0), i, "0")
+                edge.enqueue(&Rpc::new_rpc(0), i, "0")
             }
         });
     }
@@ -148,7 +148,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc(0), i, "0");
+                edge.enqueue(&Rpc::new_rpc(0), i, "0");
             }
             edge.dequeue(0);
         });

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -96,8 +96,8 @@ impl SimElement for Node {
     fn add_connection(&mut self, neighbor: String) {
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (bool, &str, &Vec<String>) {
-        return (true, &self.id, &self.neighbors);
+    fn whoami(&self) -> (&str, &Vec<String>) {
+        return (&self.id, &self.neighbors);
     }
 }
 

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -79,7 +79,7 @@ impl SimElement for Node {
         }
         ret
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: &Rpc, tick: u64, _sender: &str) {
         if (self.queue.size() as u32) < self.capacity {
             // drop packets you cannot accept
             if self.plugin.is_none() {
@@ -88,7 +88,7 @@ impl SimElement for Node {
                 self.plugin.as_mut().unwrap().recv(rpc, tick, &self.id);
                 let ret = self.plugin.as_mut().unwrap().tick(tick);
                 for filtered_rpc in ret {
-                    self.enqueue(filtered_rpc.0, tick);
+                    self.enqueue(&filtered_rpc.0, tick);
                 }
             }
         }
@@ -102,8 +102,8 @@ impl SimElement for Node {
 }
 
 impl Node {
-    pub fn enqueue(&mut self, x: Rpc, _now: u64) {
-        self.queue.add(x).unwrap();
+    pub fn enqueue(&mut self, x: &Rpc, _now: u64) {
+        self.queue.add(x.clone());
     }
     pub fn dequeue(&mut self, _now: u64) -> Option<Rpc> {
         if self.queue.size() == 0 {
@@ -155,10 +155,10 @@ mod tests {
         let mut node = Node::new("0", 2, 1, 0, None, 1);
         assert!(node.capacity == 2);
         assert!(node.egress_rate == 1);
-        node.recv(Rpc::new_rpc(0), 0, "0");
-        node.recv(Rpc::new_rpc(0), 0, "0");
+        node.recv(&Rpc::new_rpc(0), 0, "0");
+        node.recv(&Rpc::new_rpc(0), 0, "0");
         assert!(node.queue.size() == 2);
-        node.recv(Rpc::new_rpc(0), 0, "0");
+        node.recv(&Rpc::new_rpc(0), 0, "0");
         assert!(node.queue.size() == 2);
         node.tick(0);
         assert!(node.queue.size() == 1);

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -62,23 +62,19 @@ impl SimElement for Node {
             self.egress_rate as usize,
         ) {
             // send the rpc to a random neighbor, if there are any
-            let mut which_neighbor = None;
-            let neigh_len = self.neighbors.len();
-            if neigh_len > 0 {
-                let mut rng: StdRng = SeedableRng::seed_from_u64(self.seed);
-                let idx = rng.gen_range(0, neigh_len);
-                which_neighbor = Some(self.neighbors[idx].clone());
-            }
             let rpc: Rpc;
             if self.queue.size() > 0 {
                 let deq = self.dequeue(tick);
-                assert!(deq.is_some());
                 rpc = deq.unwrap();
             } else {
                 rpc = Rpc::new_rpc(tick as u32);
             }
-            if which_neighbor.is_some() {
-                ret.push((rpc, which_neighbor.unwrap()));
+            let neigh_len = self.neighbors.len();
+            if neigh_len > 0 {
+                let mut rng: StdRng = SeedableRng::seed_from_u64(self.seed);
+                let idx = rng.gen_range(0, neigh_len);
+                let which_neighbor = self.neighbors[idx].clone();
+                ret.push((rpc, which_neighbor));
             }
         }
         ret

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -79,7 +79,7 @@ impl SimElement for Node {
         }
         ret
     }
-    fn recv(&mut self, rpc: &Rpc, tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
         if (self.queue.size() as u32) < self.capacity {
             // drop packets you cannot accept
             if self.plugin.is_none() {
@@ -88,7 +88,7 @@ impl SimElement for Node {
                 self.plugin.as_mut().unwrap().recv(rpc, tick, &self.id);
                 let ret = self.plugin.as_mut().unwrap().tick(tick);
                 for filtered_rpc in ret {
-                    self.enqueue(&filtered_rpc.0, tick);
+                    self.enqueue(filtered_rpc.0, tick);
                 }
             }
         }
@@ -102,8 +102,8 @@ impl SimElement for Node {
 }
 
 impl Node {
-    pub fn enqueue(&mut self, x: &Rpc, _now: u64) {
-        let _res = self.queue.add(x.clone());
+    pub fn enqueue(&mut self, x: Rpc, _now: u64) {
+        let _res = self.queue.add(x);
     }
     pub fn dequeue(&mut self, _now: u64) -> Option<Rpc> {
         if self.queue.size() == 0 {
@@ -155,10 +155,10 @@ mod tests {
         let mut node = Node::new("0", 2, 1, 0, None, 1);
         assert!(node.capacity == 2);
         assert!(node.egress_rate == 1);
-        node.recv(&Rpc::new_rpc(0), 0, "0");
-        node.recv(&Rpc::new_rpc(0), 0, "0");
+        node.recv(Rpc::new_rpc(0), 0, "0");
+        node.recv(Rpc::new_rpc(0), 0, "0");
         assert!(node.queue.size() == 2);
-        node.recv(&Rpc::new_rpc(0), 0, "0");
+        node.recv(Rpc::new_rpc(0), 0, "0");
         assert!(node.queue.size() == 2);
         node.tick(0);
         assert!(node.queue.size() == 1);

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Node {
 }
 
 impl SimElement for Node {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, Option<String>)> {
+    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
         let mut ret = vec![];
         for _ in 0..min(
             self.queue.size() + (self.generation_rate as usize),
@@ -69,12 +69,16 @@ impl SimElement for Node {
                 let idx = rng.gen_range(0, neigh_len);
                 which_neighbor = Some(self.neighbors[idx].clone());
             }
+            let rpc: Rpc;
             if self.queue.size() > 0 {
                 let deq = self.dequeue(tick);
                 assert!(deq.is_some());
-                ret.push((deq.unwrap(), which_neighbor));
+                rpc = deq.unwrap();
             } else {
-                ret.push((Rpc::new_rpc(tick as u32), which_neighbor));
+                rpc = Rpc::new_rpc(tick as u32);
+            }
+            if which_neighbor.is_some() {
+                ret.push((rpc, which_neighbor.unwrap()));
             }
         }
         ret
@@ -103,7 +107,7 @@ impl SimElement for Node {
 
 impl Node {
     pub fn enqueue(&mut self, x: &Rpc, _now: u64) {
-        self.queue.add(x.clone());
+        let _res = self.queue.add(x.clone());
     }
     pub fn dequeue(&mut self, _now: u64) -> Option<Rpc> {
         if self.queue.size() == 0 {

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -53,9 +53,9 @@ impl SimElement for PluginWrapper {
             vec![]
         }
     }
-    fn recv(&mut self, rpc: &Rpc, _tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: Rpc, _tick: u64, _sender: &str) {
         assert!(self.stored_rpc.is_none(), "Overwriting previous RPC");
-        self.stored_rpc = Some(rpc.clone());
+        self.stored_rpc = Some(rpc);
     }
     fn add_connection(&mut self, neighbor: String) {
         // override the connection if there is already an element in it

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -36,7 +36,7 @@ impl fmt::Display for PluginWrapper {
 }
 
 impl SimElement for PluginWrapper {
-    fn tick(&mut self, _tick: u64) -> Vec<(Rpc, Option<String>)> {
+    fn tick(&mut self, _tick: u64) -> Vec<(Rpc, String)> {
         if self.stored_rpc.is_some() {
             let ret = self.execute(self.stored_rpc.as_ref().unwrap());
             self.stored_rpc = None;
@@ -44,9 +44,9 @@ impl SimElement for PluginWrapper {
                 vec![]
             } else {
                 if self.neighbor.len() > 0 {
-                    vec![(ret.unwrap(), Some(self.neighbor[0].clone()))]
+                    vec![(ret.unwrap(), self.neighbor[0].clone())]
                 } else {
-                    vec![(ret.unwrap(), None)]
+                    vec![]
                 }
             }
         } else {

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -53,9 +53,9 @@ impl SimElement for PluginWrapper {
             vec![]
         }
     }
-    fn recv(&mut self, rpc: Rpc, _tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: &Rpc, _tick: u64, _sender: &str) {
         assert!(self.stored_rpc.is_none(), "Overwriting previous RPC");
-        self.stored_rpc = Some(rpc);
+        self.stored_rpc = Some(rpc.clone());
     }
     fn add_connection(&mut self, neighbor: String) {
         // override the connection if there is already an element in it

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -66,8 +66,8 @@ impl SimElement for PluginWrapper {
             self.neighbor.push(neighbor);
         }
     }
-    fn whoami(&self) -> (bool, &str, &Vec<String>) {
-        return (false, &self.id, &self.neighbor);
+    fn whoami(&self) -> (&str, &Vec<String>) {
+        return (&self.id, &self.neighbor);
     }
 }
 

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -6,7 +6,7 @@ use rpc_lib::rpc::Rpc;
 pub trait SimElement {
     fn add_connection(&mut self, neighbor: String);
 
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, Option<String>)>;
+    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)>;
 
     fn recv(&mut self, rpc: &Rpc, tick: u64, sender: &str);
 

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -8,7 +8,7 @@ pub trait SimElement {
 
     fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)>;
 
-    fn recv(&mut self, rpc: &Rpc, tick: u64, sender: &str);
+    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
 
     // This returns the following information about a simulator element
     // 1. what its ID is

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -8,7 +8,7 @@ pub trait SimElement {
 
     fn tick(&mut self, tick: u64) -> Vec<(Rpc, Option<String>)>;
 
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
+    fn recv(&mut self, rpc: &Rpc, tick: u64, sender: &str);
 
     // This returns the following information about a simulator element
     // 1. what its ID is

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -11,10 +11,9 @@ pub trait SimElement {
     fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
 
     // This returns the following information about a simulator element
-    // 1. whether it should be included in the path
-    // 2. what its ID is
-    // 3. who its neighbors are
-    fn whoami(&self) -> (bool, &str, &Vec<String>);
+    // 1. what its ID is
+    // 2. who its neighbors are
+    fn whoami(&self) -> (&str, &Vec<String>);
 }
 
 pub trait Node {}

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -106,7 +106,7 @@ impl Simulator {
     pub fn tick(&mut self, tick: u64) {
         let mut rpc_buffer = HashMap::new();
         // tick all elements to generate Rpcs
-        // this is the send phase
+        // this is the send phase. collect all the rpcs
         for (elem_name, element_obj) in self.elements.iter_mut() {
             let rpcs = element_obj.tick(tick);
             let mut input_rpcs = vec![];
@@ -124,10 +124,8 @@ impl Simulator {
         // now start the receive phase
         for (elem_name, rpc_tuples) in rpc_buffer {
             for (rpc, dst) in rpc_tuples {
-                if dst.is_some() {
-                    let elem = self.elements.get_mut(&dst.unwrap()).unwrap();
-                    elem.recv(&rpc, tick, &elem_name);
-                }
+                let elem = self.elements.get_mut(&dst).unwrap();
+                elem.recv(&rpc, tick, &elem_name);
             }
         }
 

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -111,7 +111,7 @@ impl Simulator {
             let rpcs = element_obj.tick(tick);
             let mut input_rpcs = vec![];
             for (rpc, dst) in rpcs {
-                input_rpcs.push((rpc, dst.clone()));
+                input_rpcs.push((rpc, dst));
             }
             rpc_buffer.insert(elem_name.clone(), input_rpcs);
             println!(

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -125,7 +125,7 @@ impl Simulator {
         for (elem_name, rpc_tuples) in rpc_buffer {
             for (rpc, dst) in rpc_tuples {
                 let elem = self.elements.get_mut(&dst).unwrap();
-                elem.recv(&rpc, tick, &elem_name);
+                elem.recv(rpc, tick, &elem_name);
             }
         }
 

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -139,10 +139,7 @@ impl Simulator {
                 if dst.is_some() {
                     // Before we send this rpc on, we should update its path to include the most recently traversed node if applicable
                     // TODO: is cloning the best way to do this?
-                    let mut new_rpc = rpc.clone();
-                    if self.elements[src].whoami().0 {
-                        new_rpc.add_to_path(src);
-                    }
+                    let new_rpc = rpc.clone();
                     self.elements
                         .get_mut(dst.as_ref().clone().unwrap())
                         .unwrap()

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -6,7 +6,6 @@ use crate::node::Node;
 use crate::sim_element::SimElement;
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{Graph, NodeIndex};
-use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
@@ -21,7 +20,6 @@ impl<T: SimElement + Display> PrintableElement for T {}
 #[derive(Default)]
 pub struct Simulator {
     elements: HashMap<String, Box<dyn PrintableElement>>,
-    rpc_buffer: HashMap<String, Vec<(Rpc, Option<String>)>>,
     graph: Graph<String, String>,
     node_index_to_node: HashMap<String, NodeIndex>,
     seed: u64,
@@ -31,7 +29,6 @@ impl Simulator {
     pub fn new(seed: u64) -> Self {
         Simulator {
             elements: HashMap::new(),
-            rpc_buffer: HashMap::new(),
             graph: Graph::new(),
             node_index_to_node: HashMap::new(),
             seed,
@@ -82,7 +79,6 @@ impl Simulator {
 
     pub fn add_element<T: 'static + PrintableElement>(&mut self, id: &str, element: T) -> usize {
         self.elements.insert(id.to_string(), Box::new(element));
-        self.rpc_buffer.insert(id.to_string(), vec![]);
         return self.elements.len() - 1;
     }
 
@@ -108,45 +104,35 @@ impl Simulator {
     }
 
     pub fn tick(&mut self, tick: u64) {
-        // TODO: clean this up
+        let mut rpc_buffer = HashMap::new();
         // tick all elements to generate Rpcs
-        for (i, element) in self.elements.iter_mut() {
-            let rpcs = element.tick(tick);
+        // this is the send phase
+        for (elem_name, element_obj) in self.elements.iter_mut() {
+            let rpcs = element_obj.tick(tick);
+            let mut input_rpcs = vec![];
             for (rpc, dst) in rpcs {
-                self.rpc_buffer.get_mut(i).unwrap().push((rpc, dst));
+                input_rpcs.push((rpc, dst.clone()));
             }
+            rpc_buffer.insert(elem_name.clone(), input_rpcs);
             println!(
                 "After tick {:5}, {:45} \n\toutputs {:?}\n",
-                tick, element, self.rpc_buffer[i]
+                tick, element_obj, rpc_buffer[elem_name]
             );
         }
         print!("\n\n");
 
-        // Send these elements to the next hops
-
-        // We have to make this hashmap because if we don't, then we're iterating over and modifying the same hashmap self.elements
-        // and Rust, understandably, does not like that at all for memory reasons
-        let mut indices_to_sim_el = HashMap::new();
-        let mut j = 0;
-        for i in self.elements.keys() {
-            indices_to_sim_el.insert(j, i.clone());
-            j = j + 1;
-        }
-        for i in 0..self.elements.keys().count() {
-            let src = &indices_to_sim_el[&i];
-            while !&self.rpc_buffer[src].is_empty() {
-                let (rpc, dst) = &self.rpc_buffer.get_mut(src).unwrap().pop().unwrap();
+        // now start the receive phase
+        for (elem_name, rpc_tuples) in rpc_buffer {
+            for (rpc, dst) in rpc_tuples {
                 if dst.is_some() {
-                    // Before we send this rpc on, we should update its path to include the most recently traversed node if applicable
-                    // TODO: is cloning the best way to do this?
-                    let new_rpc = rpc.clone();
-                    self.elements
-                        .get_mut(dst.as_ref().clone().unwrap())
-                        .unwrap()
-                        .recv(new_rpc, tick, src);
+                    let elem = self.elements.get_mut(&dst.unwrap()).unwrap();
+                    elem.recv(&rpc, tick, &elem_name);
                 }
             }
         }
+
+        // Send these elements to the next hops
+
         println!("");
     }
 }


### PR DESCRIPTION
Tried to simplify a bunch of things. Ripped out the trace_path, since that is now in the rpc headers. Also simplified the simulator tick function. I think this can be even further improved, the more understanding we get from Rust. 

Does the rewrite make sense? The tests pass, but I do not know if they cover this correctly. If not, we should add a test.