### PR TITLE
Storage works

### DIFF
--- a/libs/rpc_lib/src/rpc.rs
+++ b/libs/rpc_lib/src/rpc.rs
@@ -3,18 +3,18 @@ use std::collections::HashMap;
 #[derive(PartialEq, Clone, Debug)]
 #[repr(C)]
 pub struct Rpc {
-    pub data: u32,                        // application data
+    pub data: String,                     // application data
     pub uid: u64,                         // number of hops the message has taken
     pub path: String,                     // the path that the request has taken thus far
     pub headers: HashMap<String, String>, // the "http" headers of the rpc, ie, filter-defined book keeping
 }
 
 impl Rpc {
-    pub fn new_rpc(data: u32) -> Self {
+    pub fn new_rpc(data: &str) -> Self {
         static mut COUNTER: u64 = 0;
         let ret = unsafe {
             Rpc {
-                data,
+                data: data.to_string(),
                 uid: COUNTER,
                 path: String::new(),
                 headers: HashMap::new(),

--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -63,8 +63,14 @@ impl SimElement for Edge {
         assert!(self.neighbors.len() < 2);
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
-        return (&self.id, &self.neighbors, None);
+    fn whoami(&self) -> &str {
+        &self.id
+    }
+    fn neighbors(&self) -> &Vec<String> {
+        &self.neighbors
+    }
+    fn type_specific_info(&self) -> Option<&str> {
+        None
     }
 }
 

--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -63,8 +63,8 @@ impl SimElement for Edge {
         assert!(self.neighbors.len() < 2);
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (&str, &Vec<String>) {
-        return (&self.id, &self.neighbors);
+    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
+        return (&self.id, &self.neighbors, None);
     }
 }
 
@@ -141,7 +141,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc(0), i, "0")
+                edge.enqueue(Rpc::new_rpc("0"), i, "0")
             }
         });
     }
@@ -151,7 +151,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc(0), i, "0");
+                edge.enqueue(Rpc::new_rpc("0"), i, "0");
             }
             edge.dequeue(0);
         });

--- a/sim/src/filter_types.rs
+++ b/sim/src/filter_types.rs
@@ -4,7 +4,7 @@
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
 
-pub type CodeletType = fn(*mut Filter, &Rpc) -> Option<Rpc>;
+pub type CodeletType = fn(*mut Filter, &Rpc) -> Vec<Rpc>;
 
 // This represents a piece of state of the filter
 // it either contains a user defined function, or some sort of

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -6,6 +6,7 @@ mod node;
 mod plugin_wrapper;
 mod sim_element;
 mod simulator;
+mod storage;
 
 use clap::{App, Arg};
 use rand::Rng;
@@ -76,4 +77,5 @@ fn main() {
     for tick in 0..20 {
         simulator.tick(tick);
     }
+    print!("Filter outputs:\n {0}", simulator.query_storage());
 }

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -76,7 +76,6 @@ fn main() {
     simulator.add_edge(1, "node-4", "storage", true);
     simulator.add_edge(1, "node-5", "storage", true);
 
-
     // Print the graph
     if let Some(_argument) = matches.value_of("print_graph") {
         simulator.print_graph();

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
     simulator.add_node("node-3", 10, 1, 0, plugin_str);
     simulator.add_node("node-4", 1, 1, 0, plugin_str); // in setting egress rate to 0, we are making a sink
     simulator.add_node("node-5", 1, 1, 0, plugin_str); // in setting egress rate to 0, we are making a sink
+    simulator.add_storage("storage");
 
     // edge arguments go:  delay, endpoint1, endpoint2, unidirectional
     simulator.add_edge(1, "traffic-gen", "node-1", true);
@@ -67,6 +68,14 @@ fn main() {
     //one way rpc sinks
     simulator.add_edge(1, "node-1", "node-4", true);
     simulator.add_edge(1, "node-2", "node-5", true);
+
+    // all edges to storage
+    simulator.add_edge(1, "node-1", "storage", true);
+    simulator.add_edge(1, "node-2", "storage", true);
+    simulator.add_edge(1, "node-3", "storage", true);
+    simulator.add_edge(1, "node-4", "storage", true);
+    simulator.add_edge(1, "node-5", "storage", true);
+
 
     // Print the graph
     if let Some(_argument) = matches.value_of("print_graph") {
@@ -77,5 +86,5 @@ fn main() {
     for tick in 0..20 {
         simulator.tick(tick);
     }
-    print!("Filter outputs:\n {0}", simulator.query_storage());
+    print!("Filter outputs:\n {0}", simulator.query_storage("storage"));
 }

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -109,8 +109,15 @@ impl SimElement for Node {
     fn add_connection(&mut self, neighbor: String) {
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
-        return (&self.id, &self.neighbors, None);
+
+    fn whoami(&self) -> &str {
+        return &self.id;
+    }
+    fn neighbors(&self) -> &Vec<String> {
+        return &self.neighbors;
+    }
+    fn type_specific_info(&self) -> Option<&str> {
+        return None;
     }
 }
 

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -61,16 +61,29 @@ impl SimElement for Node {
             self.queue.size() + (self.generation_rate as usize),
             self.egress_rate as usize,
         ) {
-            // send the rpc to a random neighbor, if there are any
+            // send the rpc to a random neighbor, if no neighbor specified
             let rpc: Rpc;
             if self.queue.size() > 0 {
                 let deq = self.dequeue(tick);
                 rpc = deq.unwrap();
             } else {
-                rpc = Rpc::new_rpc(tick as u32);
+                rpc = Rpc::new_rpc(&tick.to_string());
             }
             let neigh_len = self.neighbors.len();
-            if neigh_len > 0 {
+            if rpc.headers.contains_key("dest") {
+                let mut have_dest = false;
+                let dest = rpc.headers["dest"].clone();
+                for n in &self.neighbors {
+                    if n == &dest {
+                        have_dest = true;
+                        ret.push((rpc, dest));
+                        break;
+                    }
+                }
+                if !have_dest {
+                    print!("WARNING:  RPC given with invalid destination\n");
+                }
+            } else if neigh_len > 0 {
                 let mut rng: StdRng = SeedableRng::seed_from_u64(self.seed);
                 let idx = rng.gen_range(0, neigh_len);
                 let which_neighbor = self.neighbors[idx].clone();
@@ -96,8 +109,8 @@ impl SimElement for Node {
     fn add_connection(&mut self, neighbor: String) {
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (&str, &Vec<String>) {
-        return (&self.id, &self.neighbors);
+    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
+        return (&self.id, &self.neighbors, None);
     }
 }
 
@@ -155,10 +168,10 @@ mod tests {
         let mut node = Node::new("0", 2, 1, 0, None, 1);
         assert!(node.capacity == 2);
         assert!(node.egress_rate == 1);
-        node.recv(Rpc::new_rpc(0), 0, "0");
-        node.recv(Rpc::new_rpc(0), 0, "0");
+        node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.recv(Rpc::new_rpc("0"), 0, "0");
         assert!(node.queue.size() == 2);
-        node.recv(Rpc::new_rpc(0), 0, "0");
+        node.recv(Rpc::new_rpc("0"), 0, "0");
         assert!(node.queue.size() == 2);
         node.tick(0);
         assert!(node.queue.size() == 1);

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -64,8 +64,14 @@ impl SimElement for PluginWrapper {
             self.neighbor.push(neighbor);
         }
     }
-    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
-        return (&self.id, &self.neighbor, None);
+    fn whoami(&self) -> &str {
+        &self.id
+    }
+    fn neighbors(&self) -> &Vec<String> {
+        &self.neighbor
+    }
+    fn type_specific_info(&self) -> Option<&str> {
+        None
     }
 }
 

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -37,21 +37,19 @@ impl fmt::Display for PluginWrapper {
 
 impl SimElement for PluginWrapper {
     fn tick(&mut self, _tick: u64) -> Vec<(Rpc, String)> {
+        let mut to_return = vec![];
         if self.stored_rpc.is_some() {
             let ret = self.execute(self.stored_rpc.as_ref().unwrap());
             self.stored_rpc = None;
-            if ret.is_none() {
-                vec![]
-            } else {
-                if self.neighbor.len() > 0 {
-                    vec![(ret.unwrap(), self.neighbor[0].clone())]
-                } else {
-                    vec![]
+            if ret.len() > 0 {
+                for rpc in ret {
+                    if self.neighbor.len() > 0 {
+                        to_return.push((rpc, self.neighbor[0].clone()));
+                    }
                 }
             }
-        } else {
-            vec![]
         }
+        return to_return;
     }
     fn recv(&mut self, rpc: Rpc, _tick: u64, _sender: &str) {
         assert!(self.stored_rpc.is_none(), "Overwriting previous RPC");
@@ -66,8 +64,8 @@ impl SimElement for PluginWrapper {
             self.neighbor.push(neighbor);
         }
     }
-    fn whoami(&self) -> (&str, &Vec<String>) {
-        return (&self.id, &self.neighbor);
+    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
+        return (&self.id, &self.neighbor, None);
     }
 }
 
@@ -128,7 +126,7 @@ impl PluginWrapper {
         }
     }
 
-    pub fn execute(&self, input: &Rpc) -> Option<Rpc> {
+    pub fn execute(&self, input: &Rpc) -> Vec<Rpc> {
         (self.loaded_function)(self.filter, input)
     }
 }
@@ -142,9 +140,9 @@ mod tests {
         cargo_dir.push("../target/debug/libfilter_example");
         let library_str = cargo_dir.to_str().unwrap();
         let plugin = PluginWrapper::new("0", library_str);
-        let rpc = &Rpc::new_rpc(55);
-        let rpc_data = plugin.execute(rpc).unwrap().data;
-        assert!(rpc_data == 55);
+        let rpc = &Rpc::new_rpc("55");
+        let rpc_data = &plugin.execute(rpc)[0].data;
+        assert!(rpc_data == &"55".to_string());
     }
 
     #[test]
@@ -156,19 +154,26 @@ mod tests {
         let plugin2 = PluginWrapper::new("1", library_str);
         let plugin3 = PluginWrapper::new("2", library_str);
         let plugin4 = PluginWrapper::new("3", library_str);
+        let ret1: &Rpc = &plugin1.execute(&Rpc::new_rpc("5"))[0];
+        let ret2: &Rpc = &plugin2.execute(&ret1)[0];
+        let ret3: &Rpc = &plugin3.execute(&ret2)[0];
+        let ret4: &Rpc = &plugin4.execute(&ret3)[0];
+        assert!("5".to_string() == ret4.data);
+        //assert!("5".to_string() == plugin4.execute(&plugin3.execute(&plugin2.execute(&plugin1.execute(&Rpc::new_rpc("5"))[0])[0])[0].data));
+        /*
         assert!(
-            5 == plugin4
+            "5".to_string() == plugin4
                 .execute(
                     &plugin3
                         .execute(
                             &plugin2
-                                .execute(&plugin1.execute(&Rpc::new_rpc(5)).unwrap())
-                                .unwrap()
+                                .execute(&plugin1.execute(&Rpc::new_rpc("5"))[0]
                         )
-                        .unwrap()
+                        [0]
                 )
-                .unwrap()
+                [0]
                 .data
         );
+        */
     }
 }

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -10,11 +10,11 @@ pub trait SimElement {
 
     fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
 
-    // This returns the following information about a simulator element
-    // 1. what its ID is
-    // 2. who its neighbors are
-    // 3. a placeholder for any relevant element-specific information
-    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>);
+    fn whoami(&self) -> &str;
+
+    fn neighbors(&self) -> &Vec<String>;
+
+    fn type_specific_info(&self) -> Option<&str>;
 }
 
 pub trait Node {}

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -13,7 +13,8 @@ pub trait SimElement {
     // This returns the following information about a simulator element
     // 1. what its ID is
     // 2. who its neighbors are
-    fn whoami(&self) -> (&str, &Vec<String>);
+    // 3. a placeholder for any relevant element-specific information
+    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>);
 }
 
 pub trait Node {}

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -4,12 +4,15 @@
 use crate::edge::Edge;
 use crate::node::Node;
 use crate::sim_element::SimElement;
+use crate::storage::Storage;
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{Graph, NodeIndex};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
 use std::process::Command;
+
+const STORAGE_ID: &str = "storage";
 
 // Need to combine SimElement for simulation
 // and Debug for printing.
@@ -27,12 +30,25 @@ pub struct Simulator {
 
 impl Simulator {
     pub fn new(seed: u64) -> Self {
-        Simulator {
+        let mut sim = Simulator {
             elements: HashMap::new(),
             graph: Graph::new(),
             node_index_to_node: HashMap::new(),
             seed,
-        }
+        };
+
+        // set up storage
+        let storage = Storage::new(STORAGE_ID);
+        sim.add_element(STORAGE_ID, storage);
+        sim.node_index_to_node.insert(
+            STORAGE_ID.to_string(),
+            sim.graph.add_node(STORAGE_ID.to_string()),
+        );
+        return sim;
+    }
+
+    pub fn query_storage(&mut self) -> &str {
+        self.elements[STORAGE_ID].whoami().2.unwrap()
     }
 
     pub fn add_node(
@@ -54,6 +70,7 @@ impl Simulator {
         self.add_element(id, node);
         self.node_index_to_node
             .insert(id.to_string(), self.graph.add_node(id.to_string()));
+        self.add_edge(1, id, STORAGE_ID, true);
     }
 
     pub fn add_edge(&mut self, delay: u32, element1: &str, element2: &str, unidirectional: bool) {

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -12,8 +12,6 @@ use std::fmt::Display;
 use std::fs;
 use std::process::Command;
 
-const STORAGE_ID: &str = "storage";
-
 // Need to combine SimElement for simulation
 // and Debug for printing.
 // Uses this suggestion: https://stackoverflow.com/a/28898575
@@ -30,25 +28,16 @@ pub struct Simulator {
 
 impl Simulator {
     pub fn new(seed: u64) -> Self {
-        let mut sim = Simulator {
+        Simulator {
             elements: HashMap::new(),
             graph: Graph::new(),
             node_index_to_node: HashMap::new(),
             seed,
-        };
-
-        // set up storage
-        let storage = Storage::new(STORAGE_ID);
-        sim.add_element(STORAGE_ID, storage);
-        sim.node_index_to_node.insert(
-            STORAGE_ID.to_string(),
-            sim.graph.add_node(STORAGE_ID.to_string()),
-        );
-        return sim;
+        }
     }
 
-    pub fn query_storage(&mut self) -> &str {
-        self.elements[STORAGE_ID].whoami().2.unwrap()
+    pub fn query_storage(&mut self, storage_id: &str) -> &str {
+        self.elements[storage_id].whoami().2.unwrap()
     }
 
     pub fn add_node(
@@ -70,7 +59,6 @@ impl Simulator {
         self.add_element(id, node);
         self.node_index_to_node
             .insert(id.to_string(), self.graph.add_node(id.to_string()));
-        self.add_edge(1, id, STORAGE_ID, true);
     }
 
     pub fn add_edge(&mut self, delay: u32, element1: &str, element2: &str, unidirectional: bool) {
@@ -92,6 +80,16 @@ impl Simulator {
             self.add_connection(&id, element1);
             self.add_connection(element2, &id);
         }
+    }
+
+    pub fn add_storage(&mut self, id: &str) {
+        let storage = Storage::new(id);
+        self.add_element(id, storage);
+        self.node_index_to_node.insert(
+            id.to_string(),
+            self.graph.add_node(id.to_string()),
+        );
+
     }
 
     pub fn add_element<T: 'static + PrintableElement>(&mut self, id: &str, element: T) -> usize {

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -37,7 +37,7 @@ impl Simulator {
     }
 
     pub fn query_storage(&mut self, storage_id: &str) -> &str {
-        self.elements[storage_id].whoami().2.unwrap()
+        self.elements[storage_id].type_specific_info().unwrap()
     }
 
     pub fn add_node(
@@ -85,11 +85,8 @@ impl Simulator {
     pub fn add_storage(&mut self, id: &str) {
         let storage = Storage::new(id);
         self.add_element(id, storage);
-        self.node_index_to_node.insert(
-            id.to_string(),
-            self.graph.add_node(id.to_string()),
-        );
-
+        self.node_index_to_node
+            .insert(id.to_string(), self.graph.add_node(id.to_string()));
     }
 
     pub fn add_element<T: 'static + PrintableElement>(&mut self, id: &str, element: T) -> usize {
@@ -129,10 +126,10 @@ impl Simulator {
                 input_rpcs.push((rpc, dst));
             }
             rpc_buffer.insert(elem_name.clone(), input_rpcs);
-            println!(
-                "After tick {:5}, {:45} \n\toutputs {:?}\n",
-                tick, element_obj, rpc_buffer[elem_name]
-            );
+            //println!(
+            //    "After tick {:5}, {:45} \n\toutputs {:?}\n",
+            //    tick, element_obj, rpc_buffer[elem_name]
+            //);
         }
         print!("\n\n");
 

--- a/sim/src/storage.rs
+++ b/sim/src/storage.rs
@@ -1,0 +1,77 @@
+//! An abstraction of a node.  The node can have a plugin, which is meant to reprsent a WebAssembly filter
+//! A node is a sim_element.
+
+use crate::sim_element::SimElement;
+use rpc_lib::rpc::Rpc;
+use std::fmt;
+
+#[derive(Default)]
+pub struct Storage {
+    data: String,           // all the data that has been stored
+    id: String,             // id
+    neighbors: Vec<String>, // who is the node connected to
+}
+
+impl fmt::Display for Storage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(width) = f.width() {
+            write!(
+                f,
+                "{:width$}",
+                &format!("Storage {{ queue : {} }}", self.id),
+                width = width
+            )
+        } else {
+            write!(f, "Storage {{ id : {} }}", self.id,)
+        }
+    }
+}
+
+impl SimElement for Storage {
+    // storage never sends messages out, only receives them, so we return an empty vector
+    fn tick(&mut self, _tick: u64) -> Vec<(Rpc, String)> {
+        return vec![];
+    }
+
+    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
+        self.store(rpc, tick);
+    }
+    fn add_connection(&mut self, neighbor: String) {
+        self.neighbors.push(neighbor);
+    }
+    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
+        return (&self.id, &self.neighbors, Some(&self.data));
+    }
+}
+
+impl Storage {
+    pub fn store(&mut self, x: Rpc, _now: u64) {
+        self.data.push_str(&x.data);
+        self.data.push_str("\n");
+    }
+    pub fn new(id: &str) -> Storage {
+        Storage {
+            data: String::new(),
+            id: id.to_string(),
+            neighbors: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_storage_creation() {
+        let _storage = Storage::new("0");
+    }
+
+    #[test]
+    fn test_query_storage() {
+        let mut storage = Storage::new("0");
+        storage.recv(Rpc::new_rpc("0"), 0, "node");
+        let ret = storage.whoami().2.unwrap();
+        assert!(ret == "0\n".to_string());
+    }
+}

--- a/sim/src/storage.rs
+++ b/sim/src/storage.rs
@@ -34,13 +34,20 @@ impl SimElement for Storage {
     }
 
     fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
+        print!("receving");
         self.store(rpc, tick);
     }
     fn add_connection(&mut self, neighbor: String) {
         self.neighbors.push(neighbor);
     }
-    fn whoami(&self) -> (&str, &Vec<String>, Option<&str>) {
-        return (&self.id, &self.neighbors, Some(&self.data));
+    fn whoami(&self) -> &str {
+        &self.id
+    }
+    fn neighbors(&self) -> &Vec<String> {
+        &self.neighbors
+    }
+    fn type_specific_info(&self) -> Option<&str> {
+        Some(&self.data)
     }
 }
 
@@ -71,7 +78,7 @@ mod tests {
     fn test_query_storage() {
         let mut storage = Storage::new("0");
         storage.recv(Rpc::new_rpc("0"), 0, "node");
-        let ret = storage.whoami().2.unwrap();
+        let ret = storage.type_specific_info().unwrap();
         assert!(ret == "0\n".to_string());
     }
 }


### PR DESCRIPTION
I made a storage node, and it can be queried by the simulator.  I also changed RPC's data to a string so that we can send filter results as data in messages, and I gave every node a connection to storage on initialization.

Because the filter can now output both RPCs that are used for the "application" and RPCs that go to storage, I changed filters to output a vector of RPCs.  RPCs can optionally contain destination header information;  if they don't have any, they are sent to a random neighbor like before.