### PR TITLE
Add downcast for storage.

### DIFF
--- a/sim/src/edge.rs
+++ b/sim/src/edge.rs
@@ -3,6 +3,7 @@
 extern crate test;
 
 use crate::sim_element::SimElement;
+use core::any::Any;
 use queues::*;
 use rpc_lib::rpc::Rpc;
 use std::fmt;
@@ -69,8 +70,9 @@ impl SimElement for Edge {
     fn neighbors(&self) -> &Vec<String> {
         &self.neighbors
     }
-    fn type_specific_info(&self) -> Option<&str> {
-        None
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/sim/src/node.rs
+++ b/sim/src/node.rs
@@ -3,6 +3,7 @@
 
 use crate::plugin_wrapper::PluginWrapper;
 use crate::sim_element::SimElement;
+use core::any::Any;
 use queues::*;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rpc_lib::rpc::Rpc;
@@ -116,8 +117,8 @@ impl SimElement for Node {
     fn neighbors(&self) -> &Vec<String> {
         return &self.neighbors;
     }
-    fn type_specific_info(&self) -> Option<&str> {
-        return None;
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/sim/src/plugin_wrapper.rs
+++ b/sim/src/plugin_wrapper.rs
@@ -4,6 +4,7 @@
 
 use crate::filter_types::{CodeletType, Filter, NewWithEnvoyProperties};
 use crate::sim_element::SimElement;
+use core::any::Any;
 use rpc_lib::rpc::Rpc;
 use std::collections::HashMap;
 use std::env;
@@ -69,8 +70,8 @@ impl SimElement for PluginWrapper {
     fn neighbors(&self) -> &Vec<String> {
         &self.neighbor
     }
-    fn type_specific_info(&self) -> Option<&str> {
-        None
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/sim/src/sim_element.rs
+++ b/sim/src/sim_element.rs
@@ -1,6 +1,7 @@
 //! A sim_element is something that takes in RPCs and give them to other sim_elements.
 //! Right now the only sim_elements are nodes, edges, and plugin_wrappers.
 
+use core::any::Any;
 use rpc_lib::rpc::Rpc;
 
 pub trait SimElement {
@@ -14,7 +15,7 @@ pub trait SimElement {
 
     fn neighbors(&self) -> &Vec<String>;
 
-    fn type_specific_info(&self) -> Option<&str>;
+    fn as_any(&self) -> &dyn Any;
 }
 
 pub trait Node {}

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -37,7 +37,9 @@ impl Simulator {
     }
 
     pub fn query_storage(&mut self, storage_id: &str) -> &str {
-        self.elements[storage_id].type_specific_info().unwrap()
+        let storage_box = &self.elements[storage_id];
+        let storage = storage_box.as_any().downcast_ref::<Storage>().unwrap();
+        return storage.query();
     }
 
     pub fn add_node(

--- a/sim/src/simulator.rs
+++ b/sim/src/simulator.rs
@@ -38,8 +38,10 @@ impl Simulator {
 
     pub fn query_storage(&mut self, storage_id: &str) -> &str {
         let storage_box = &self.elements[storage_id];
-        let storage = storage_box.as_any().downcast_ref::<Storage>().unwrap();
-        return storage.query();
+        return match storage_box.as_any().downcast_ref::<Storage>() {
+            Some(storage) => storage.query(),
+            None => panic!("Expected storage element but got {0}", storage_box),
+        };
     }
 
     pub fn add_node(

--- a/sim/src/storage.rs
+++ b/sim/src/storage.rs
@@ -84,7 +84,7 @@ mod tests {
     fn test_query_storage() {
         let mut storage = Storage::new("0");
         storage.recv(Rpc::new_rpc("0"), 0, "node");
-        let ret = storage.query().unwrap();
+        let ret = storage.query();
         assert!(ret == "0\n".to_string());
     }
 }

--- a/sim/src/storage.rs
+++ b/sim/src/storage.rs
@@ -2,6 +2,7 @@
 //! A node is a sim_element.
 
 use crate::sim_element::SimElement;
+use core::any::Any;
 use rpc_lib::rpc::Rpc;
 use std::fmt;
 
@@ -45,8 +46,8 @@ impl SimElement for Storage {
     fn neighbors(&self) -> &Vec<String> {
         &self.neighbors
     }
-    fn type_specific_info(&self) -> Option<&str> {
-        Some(&self.data)
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -57,6 +58,9 @@ impl Storage {
             self.data.push_str(&x.data);
             self.data.push_str("\n");
         }
+    }
+    pub fn query(&self) -> &str {
+        &self.data
     }
     pub fn new(id: &str) -> Storage {
         Storage {
@@ -78,13 +82,9 @@ mod tests {
 
     #[test]
     fn test_query_storage() {
-        let mut storage = Storage::new("storage");
-        let mut rpc = Rpc::new_rpc("0");
-        rpc.headers
-            .insert("dest".to_string(), "storage".to_string());
-        storage.recv(rpc, 0, "node");
-        let ret = storage.type_specific_info().unwrap();
-        print!("ret: {0}\n", ret);
+        let mut storage = Storage::new("0");
+        storage.recv(Rpc::new_rpc("0"), 0, "node");
+        let ret = storage.query().unwrap();
         assert!(ret == "0\n".to_string());
     }
 }

--- a/sim/src/storage.rs
+++ b/sim/src/storage.rs
@@ -82,8 +82,11 @@ mod tests {
 
     #[test]
     fn test_query_storage() {
-        let mut storage = Storage::new("0");
-        storage.recv(Rpc::new_rpc("0"), 0, "node");
+        let mut storage = Storage::new("storage");
+        let mut rpc = Rpc::new_rpc("0");
+        rpc.headers
+            .insert("dest".to_string(), "storage".to_string());
+        storage.recv(rpc, 0, "node");
         let ret = storage.query();
         assert!(ret == "0\n".to_string());
     }


### PR DESCRIPTION
Implements downcasting for the simulator trait nodes. This means we do not have to add functions at the top level every time we add a new type of node.