### PR TITLE
Ingress and egress filtering

### DIFF
--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -32,8 +32,6 @@ impl SimElement for Gateway {
                 .insert("direction".to_string(), "request".to_string());
             rpc.headers
                 .insert("src".to_string(), self.core_node.id.to_string());
-            rpc.headers
-                .insert("dest".to_string(), "productpage-v1".to_string());
             ret.push((rpc, "productpage-v1".to_string()));
         }
         ret

--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -32,6 +32,8 @@ impl SimElement for Gateway {
                 .insert("direction".to_string(), "request".to_string());
             rpc.headers
                 .insert("src".to_string(), self.core_node.id.to_string());
+            rpc.headers
+                .insert("dest".to_string(), "productpage-v1".to_string());
             ret.push((rpc, "productpage-v1".to_string()));
         }
         ret
@@ -80,6 +82,7 @@ mod tests {
     #[test]
     fn test_node_capacity_and_egress_rate() {
         let mut node = Gateway::new("0", 2, 1, 0, 1);
+        node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
         node.core_node.recv(Rpc::new_rpc("0"), 0, "0");

--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -20,7 +20,7 @@ impl fmt::Display for Gateway {
 }
 
 impl SimElement for Gateway {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut ret = vec![];
         for _ in 0..min(
             self.core_node.generation_rate as usize,
@@ -32,7 +32,9 @@ impl SimElement for Gateway {
                 .insert("direction".to_string(), "request".to_string());
             rpc.headers
                 .insert("src".to_string(), self.core_node.id.to_string());
-            ret.push((rpc, "productpage-v1".to_string()));
+            rpc.headers
+                .insert("dest".to_string(), "productpage-v1".to_string());
+            ret.push(rpc);
         }
         ret
     }

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -41,10 +41,10 @@ impl SimElement for LeafNode {
                 rpc.headers
                     .insert("src".to_string(), self.core_node.id.to_string());
                 rpc.headers
-                    .insert("location".to_string(), "egress".to_string());
-                rpc.headers
                     .insert("direction".to_string(), "response".to_string());
                 if let Some(plugin) = self.core_node.plugin.as_mut() {
+                    rpc.headers
+                        .insert("location".to_string(), "egress".to_string());
                     plugin.recv(rpc, tick, &self.core_node.id);
                     let filtered_rpcs = plugin.tick(tick);
                     for filtered_rpc in filtered_rpcs {

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -21,7 +21,7 @@ impl fmt::Display for LeafNode {
 }
 
 impl SimElement for LeafNode {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut ret = vec![];
         for _ in 0..min(
             self.core_node.queue.size(),
@@ -48,13 +48,10 @@ impl SimElement for LeafNode {
                     plugin.recv(rpc, tick, &self.core_node.id);
                     let filtered_rpcs = plugin.tick(tick);
                     for filtered_rpc in filtered_rpcs {
-                        ret.push((
-                            filtered_rpc.0.clone(),
-                            filtered_rpc.0.headers["dest"].clone(),
-                        ));
+                        ret.push(filtered_rpc.clone());
                     }
                 } else {
-                    ret.push((rpc.clone(), dest.to_string()));
+                    ret.push(rpc.clone());
                 }
             } else {
                 panic!("Leaf node is missing source header for forwarding! Invalid RPC.");

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -27,29 +27,28 @@ impl SimElement for LeafNode {
             self.core_node.queue.size(),
             self.core_node.egress_rate as usize,
         ) {
+            let mut rpc: Rpc;
             if self.core_node.queue.size() > 0 {
-                let mut deq = self.core_node.dequeue(tick).unwrap();
-                // 1. change src/dst headers appropriately, as well as request/response stuff
-                let new_dest = self.route_rpc(&deq);
-
-                let dest = deq.headers.get_mut("dest").unwrap();
-                *dest = new_dest.clone();
-                let src = deq.headers.get_mut("src").unwrap();
-                *src = self.core_node.id.clone();
-                let direction = deq.headers.get_mut("direction").unwrap();
-                if direction == "request" {
-                    *direction = "response".to_string();
-                } else {
-                    *direction = "request".to_string();
-                }
-
-                // 2. If there's a plugin, run it through the plugin and then put into ret
+                let deq = self.core_node.dequeue(tick);
+                rpc = deq.unwrap();
+            } else {
+                // no rpc in the queue, we only forward so nothing to do
+                continue;
+            }
+            // forward requests/responses from productpage or reviews
+            if rpc.headers.contains_key("src") {
+                let dest = self.choose_destination(&rpc);
+                rpc.headers.insert("dest".to_string(), dest.clone());
+                rpc.headers
+                    .insert("src".to_string(), self.core_node.id.to_string());
+                rpc.headers
+                    .insert("location".to_string(), "egress".to_string());
                 if self.core_node.plugin.is_some() {
                     self.core_node
                         .plugin
                         .as_mut()
                         .unwrap()
-                        .recv(deq, tick, &self.core_node.id);
+                        .recv(rpc, tick, &self.core_node.id);
                     let filtered_rpcs = self.core_node.plugin.as_mut().unwrap().tick(tick);
                     for filtered_rpc in filtered_rpcs {
                         ret.push((
@@ -58,30 +57,16 @@ impl SimElement for LeafNode {
                         ));
                     }
                 } else {
-                    ret.push((deq, new_dest.clone()));
+                    ret.push((rpc.clone(), dest.to_string()));
                 }
+            } else {
+                panic!("Reviews node is missing source header for forwarding! Invalid RPC.");
             }
         }
         ret
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
-        if (self.core_node.queue.size() as u32) < self.core_node.capacity {
-            // drop packets you cannot accept
-            if self.core_node.plugin.is_none() {
-                self.core_node.enqueue(rpc, tick);
-            } else {
-                // inbound filter check
-                self.core_node
-                    .plugin
-                    .as_mut()
-                    .unwrap()
-                    .recv(rpc, tick, &self.core_node.id);
-                let ret = self.core_node.plugin.as_mut().unwrap().tick(tick);
-                for inbound_rpc in ret {
-                    self.core_node.enqueue(inbound_rpc.0, tick);
-                }
-            }
-        }
+    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str) {
+        self.core_node.recv(rpc, tick, sender);
     }
     fn add_connection(&mut self, neighbor: String) {
         self.core_node.add_connection(neighbor)
@@ -105,7 +90,7 @@ impl LeafNode {
         LeafNode { core_node }
     }
 
-    pub fn route_rpc(&self, rpc: &Rpc) -> String {
+    pub fn choose_destination(&self, rpc: &Rpc) -> String {
         // "respond to every node that has sent a request"
         if rpc.headers.contains_key("src") {
             return rpc.headers["src"].to_string();

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -45,10 +45,11 @@ impl SimElement for ProductPage {
                     new_rpc
                         .headers
                         .insert("src".to_string(), self.core_node.id.to_string());
-                    new_rpc
-                        .headers
-                        .insert("location".to_string(), "egress".to_string());
                     if let Some(plugin) = self.core_node.plugin.as_mut() {
+                        new_rpc
+                            .headers
+                            .insert("location".to_string(), "egress".to_string());
+
                         plugin.recv(new_rpc, tick, &self.core_node.id);
                         let filtered_rpcs = plugin.tick(tick);
                         for filtered_rpc in filtered_rpcs {

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -22,7 +22,7 @@ impl fmt::Display for ProductPage {
 }
 
 impl SimElement for ProductPage {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut ret = vec![];
         for _ in 0..min(
             self.core_node.queue.size(),
@@ -30,8 +30,7 @@ impl SimElement for ProductPage {
         ) {
             let rpc: Rpc;
             if self.core_node.queue.size() > 0 {
-                let deq = self.core_node.dequeue(tick);
-                rpc = deq.unwrap();
+                rpc = self.core_node.dequeue(tick).unwrap();
             } else {
                 // no rpc in the queue, we only forward so nothing to do
                 continue;
@@ -53,13 +52,10 @@ impl SimElement for ProductPage {
                         plugin.recv(new_rpc, tick, &self.core_node.id);
                         let filtered_rpcs = plugin.tick(tick);
                         for filtered_rpc in filtered_rpcs {
-                            ret.push((
-                                filtered_rpc.0.clone(),
-                                filtered_rpc.0.headers["dest"].clone(),
-                            ));
+                            ret.push(filtered_rpc);
                         }
                     } else {
-                        ret.push((new_rpc, dest.clone()))
+                        ret.push(new_rpc)
                     }
                 }
             } else {

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -7,6 +7,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use rpc_lib::rpc::Rpc;
 use sim::node::node_fmt_with_name;
 use sim::node::Node;
+use sim::node::RpcWithDst;
 use sim::sim_element::SimElement;
 use std::cmp::min;
 use std::fmt;
@@ -23,55 +24,63 @@ impl fmt::Display for ProductPage {
 
 impl SimElement for ProductPage {
     fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
-        let mut ret = vec![];
-        let review_nodes = vec!["reviews-v1", "reviews-v2", "reviews-v3"];
-        let mut rng: StdRng = SeedableRng::seed_from_u64(self.core_node.seed);
-
+        let mut ret = Vec::new();
         for _ in 0..min(
             self.core_node.queue.size(),
             self.core_node.egress_rate as usize,
         ) {
-            let mut rpc: Rpc;
+            let rpc_dst: RpcWithDst;
             if self.core_node.queue.size() > 0 {
                 let deq = self.core_node.dequeue(tick);
-                rpc = deq.unwrap();
+                rpc_dst = deq.unwrap();
             } else {
                 // No RPC in the queue and we only forward. So nothing to do
                 continue;
             }
-            // Forward requests/responses from the gateway to one of reviews
-            // Also send a request to details-v1
-            // If we get a reply from one of reviews or details,
-            // send it back to the gateway
-            if rpc.headers.contains_key("src") {
-                let source: &str = &rpc.headers["src"];
-                if review_nodes.contains(&source) || source == "details-v1" {
-                    rpc.headers
-                        .insert("src".to_string(), self.core_node.id.to_string());
-                    ret.push((rpc, "gateway".to_string()));
-                } else if source == "gateway" {
-                    let idx = rng.gen_range(0, review_nodes.len());
-                    let dest = review_nodes[idx];
-                    rpc.headers
-                        .insert("src".to_string(), self.core_node.id.to_string());
-                    ret.push((rpc.clone(), dest.to_string()));
-                    // also send a request to details-v1
-                    ret.push((rpc, "details-v1".to_string()));
-                } else if source == &self.core_node.id {
-                    // if we are creating a new RPC, eg, we are sending to storage
-                    let dest: &str = &rpc.headers["dest"];
-                    ret.push((rpc.clone(), dest.to_string()));
-                } else {
-                    panic!("ProductPage node does not have a valid source!");
-                }
-            } else {
-                panic!("ProductPage node is missing source header for forwarding! Invalid RPC.");
-            }
+            ret.push((rpc_dst.rpc, rpc_dst.destination));
         }
         ret
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str) {
-        self.core_node.recv(rpc, tick, sender)
+    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
+        if (self.core_node.queue.size() as u32) < self.core_node.capacity {
+            // drop packets you cannot accept
+            if self.core_node.plugin.is_none() {
+                let routed_rpc = self.route_rpc(rpc);
+                for rpc in routed_rpc {
+                    self.core_node.enqueue(rpc, tick);
+                }
+            } else {
+                // inbound filter check
+                self.core_node
+                    .plugin
+                    .as_mut()
+                    .unwrap()
+                    .recv(rpc, tick, &self.core_node.id);
+                let ret = self.core_node.plugin.as_mut().unwrap().tick(tick);
+                for inbound_rpc in ret {
+                    // route packet
+                    let routed_rpcs = self.route_rpc(inbound_rpc.0);
+                    // outbound filter check
+                    for routed_rpc in routed_rpcs {
+                        self.core_node.plugin.as_mut().unwrap().recv(
+                            routed_rpc.rpc,
+                            tick,
+                            &self.core_node.id,
+                        );
+                        let outbound_rpcs = self.core_node.plugin.as_mut().unwrap().tick(tick);
+                        for outbound_rpc in outbound_rpcs {
+                            self.core_node.enqueue(
+                                RpcWithDst {
+                                    rpc: outbound_rpc.0,
+                                    destination: outbound_rpc.1,
+                                },
+                                tick,
+                            );
+                        }
+                    }
+                }
+            }
+        }
     }
     fn add_connection(&mut self, neighbor: String) {
         self.core_node.add_connection(neighbor)
@@ -99,6 +108,52 @@ impl ProductPage {
         let core_node = Node::new(id, capacity, egress_rate, 0, plugin, seed);
         ProductPage { core_node }
     }
+
+    pub fn route_rpc(&self, mut rpc: Rpc) -> Vec<RpcWithDst> {
+        let mut ret = vec![];
+        let review_nodes = vec!["reviews-v1", "reviews-v2", "reviews-v3"];
+        let mut rng: StdRng = SeedableRng::seed_from_u64(self.core_node.seed);
+        if rpc.headers.contains_key("src") {
+            let source: &str = &rpc.headers["src"];
+            if review_nodes.contains(&source) || source == "details-v1" {
+                rpc.headers
+                    .insert("src".to_string(), self.core_node.id.to_string());
+                rpc.headers
+                    .insert("dest".to_string(), "gateway".to_string());
+                ret.push(RpcWithDst {
+                    rpc,
+                    destination: "gateway".to_string(),
+                });
+            } else if source == "gateway" {
+                let idx = rng.gen_range(0, review_nodes.len());
+                let dest = review_nodes[idx];
+                rpc.headers
+                    .insert("src".to_string(), self.core_node.id.to_string());
+                rpc.headers.insert("dest".to_string(), dest.to_string());
+                ret.push(RpcWithDst {
+                    rpc: rpc.clone(),
+                    destination: dest.to_string(),
+                });
+                // also send a request to details-v1
+                ret.push(RpcWithDst {
+                    rpc,
+                    destination: "details-v1".to_string(),
+                });
+            } else if source == &self.core_node.id {
+                // if we are creating a new RPC, eg, we are sending to storage
+                let dest: &str = &rpc.headers["dest"];
+                ret.push(RpcWithDst {
+                    rpc: rpc.clone(),
+                    destination: dest.to_string(),
+                });
+            } else {
+                panic!("ProductPage node does not have a valid source!");
+            }
+        } else {
+            panic!("ProductPage node is missing source header for forwarding! Invalid RPC.");
+        }
+        ret
+    }
 }
 
 #[cfg(test)]
@@ -114,6 +169,7 @@ mod tests {
     #[test]
     fn test_node_capacity_and_egress_rate() {
         let mut node = ProductPage::new("0", 2, 1, None, 0);
+        node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
         node.core_node.recv(Rpc::new_rpc("0"), 0, "0");

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -21,7 +21,7 @@ impl fmt::Display for Reviews {
 }
 
 impl SimElement for Reviews {
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut ret = vec![];
         for _ in 0..min(
             self.core_node.queue.size(),
@@ -47,13 +47,10 @@ impl SimElement for Reviews {
                     plugin.recv(rpc, tick, &self.core_node.id);
                     let filtered_rpcs = plugin.tick(tick);
                     for filtered_rpc in filtered_rpcs {
-                        ret.push((
-                            filtered_rpc.0.clone(),
-                            filtered_rpc.0.headers["dest"].clone(),
-                        ));
+                        ret.push(filtered_rpc.clone());
                     }
                 } else {
-                    ret.push((rpc, dest.clone()));
+                    ret.push(rpc);
                 }
             } else {
                 panic!("Reviews node is missing source header for forwarding! Invalid RPC.");

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -41,9 +41,9 @@ impl SimElement for Reviews {
                 rpc.headers.insert("dest".to_string(), dest.clone());
                 rpc.headers
                     .insert("src".to_string(), self.core_node.id.to_string());
-                rpc.headers
-                    .insert("location".to_string(), "egress".to_string());
                 if let Some(plugin) = self.core_node.plugin.as_mut() {
+                    rpc.headers
+                        .insert("location".to_string(), "egress".to_string());
                     plugin.recv(rpc, tick, &self.core_node.id);
                     let filtered_rpcs = plugin.tick(tick);
                     for filtered_rpc in filtered_rpcs {

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -43,13 +43,9 @@ impl SimElement for Reviews {
                     .insert("src".to_string(), self.core_node.id.to_string());
                 rpc.headers
                     .insert("location".to_string(), "egress".to_string());
-                if self.core_node.plugin.is_some() {
-                    self.core_node
-                        .plugin
-                        .as_mut()
-                        .unwrap()
-                        .recv(rpc, tick, &self.core_node.id);
-                    let filtered_rpcs = self.core_node.plugin.as_mut().unwrap().tick(tick);
+                if let Some(plugin) = self.core_node.plugin.as_mut() {
+                    plugin.recv(rpc, tick, &self.core_node.id);
+                    let filtered_rpcs = plugin.tick(tick);
                     for filtered_rpc in filtered_rpcs {
                         ret.push((
                             filtered_rpc.0.clone(),
@@ -91,17 +87,14 @@ impl Reviews {
     }
 
     pub fn choose_destination(&self, rpc: &Rpc) -> String {
-        if rpc.headers.contains_key("src") {
-            let source = &rpc.headers["src"];
-            if source == "ratings-v1" {
-                return "productpage-v1".to_string();
-            } else if source == "productpage-v1" {
-                return "ratings-v1".to_string();
-            } else {
-                panic!("Unexpected RPC source {:?}", source);
-            }
+        let source = &rpc.headers["src"];
+        if source == "ratings-v1" {
+            return "productpage-v1".to_string();
+        } else if source == "productpage-v1" {
+            return "ratings-v1".to_string();
+        } else {
+            panic!("Unexpected RPC source {:?}", source);
         }
-        panic!("Reviews node is missing source header for forwarding! Invalid RPC.");
     }
 }
 

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -86,7 +86,8 @@ impl SimElement for Node {
 
                 // 2. If there's a plugin, run it through the plugin and then put into ret
                 if self.plugin.is_some() {
-                    deq.headers.insert("location".to_string(), "egress".to_string());
+                    deq.headers
+                        .insert("location".to_string(), "egress".to_string());
                     self.plugin.as_mut().unwrap().recv(deq, tick, &self.id);
                     let filtered_rpcs = self.plugin.as_mut().unwrap().tick(tick);
                     for filtered_rpc in filtered_rpcs {
@@ -135,7 +136,8 @@ impl SimElement for Node {
                 self.enqueue(rpc, tick);
             } else {
                 // inbound filter check
-                rpc.headers.insert("location".to_string(), "ingress".to_string());
+                rpc.headers
+                    .insert("location".to_string(), "ingress".to_string());
                 self.plugin.as_mut().unwrap().recv(rpc, tick, &self.id);
                 let ret = self.plugin.as_mut().unwrap().tick(tick);
                 for inbound_rpc in ret {

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -70,7 +70,7 @@ impl SimElement for Node {
                 let mut deq = self.dequeue(tick).unwrap();
 
                 // 1. change src/dst headers appropriately
-                let new_dest = self.route_rpc(&deq);
+                let new_dest = self.choose_destination(&deq);
                 if !deq.headers.contains_key("dest") {
                     deq.headers.insert("dest".to_string(), new_dest.clone());
                 } else {
@@ -106,7 +106,7 @@ impl SimElement for Node {
                     .insert("direction".to_string(), "request".to_string());
                 new_rpc
                     .headers
-                    .insert("dest".to_string(), self.route_rpc(&new_rpc));
+                    .insert("dest".to_string(), self.choose_destination(&new_rpc));
                 if self.plugin.is_some() {
                     self.plugin.as_mut().unwrap().recv(new_rpc, tick, &self.id);
                     let filtered_rpcs = self.plugin.as_mut().unwrap().tick(tick);
@@ -117,7 +117,7 @@ impl SimElement for Node {
                         ));
                     }
                 } else {
-                    let new_dest = self.route_rpc(&new_rpc);
+                    let new_dest = self.choose_destination(&new_rpc);
                     ret.push((new_rpc, new_dest));
                 }
             }
@@ -175,7 +175,7 @@ impl Node {
     }
 
     // given an RPC, returns the neighbor it should be sent to
-    pub fn route_rpc(&mut self, rpc: &Rpc) -> String {
+    pub fn choose_destination(&mut self, rpc: &Rpc) -> String {
         if rpc.headers.contains_key("dest") {
             let dest = &rpc.headers["dest"].clone();
             for n in &self.neighbors {

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -77,16 +77,20 @@ impl SimElement for Node {
                 let rpc_dst: RpcWithDst;
                 rpc_dst = deq.unwrap();
                 if self.plugin.is_some() {
-                    self.plugin.as_mut().unwrap().recv(rpc_dst.rpc, tick, &self.id);
+                    self.plugin
+                        .as_mut()
+                        .unwrap()
+                        .recv(rpc_dst.rpc, tick, &self.id);
                     let filtered_rpcs = self.plugin.as_mut().unwrap().tick(tick);
                     for filtered_rpc in filtered_rpcs {
-                        ret.push((filtered_rpc.0.clone(), filtered_rpc.0.headers["dest"].clone()));
+                        ret.push((
+                            filtered_rpc.0.clone(),
+                            filtered_rpc.0.headers["dest"].clone(),
+                        ));
                     }
-                }
-                else {
+                } else {
                     ret.push((rpc_dst.rpc, rpc_dst.destination));
                 }
-                 
             } else {
                 let rpcs_dst = self.route_rpc(Rpc::new_rpc(&tick.to_string()));
                 for mut rpc_dst in rpcs_dst {
@@ -95,13 +99,18 @@ impl SimElement for Node {
                         .headers
                         .insert("direction".to_string(), "request".to_string());
                     if self.plugin.is_some() {
-                        self.plugin.as_mut().unwrap().recv(rpc_dst.rpc, tick, &self.id);
+                        self.plugin
+                            .as_mut()
+                            .unwrap()
+                            .recv(rpc_dst.rpc, tick, &self.id);
                         let filtered_rpcs = self.plugin.as_mut().unwrap().tick(tick);
                         for filtered_rpc in filtered_rpcs {
-                            ret.push((filtered_rpc.0.clone(), filtered_rpc.0.headers["dest"].clone()));
+                            ret.push((
+                                filtered_rpc.0.clone(),
+                                filtered_rpc.0.headers["dest"].clone(),
+                            ));
                         }
-                    }
-                    else {
+                    } else {
                         ret.push((rpc_dst.rpc, rpc_dst.destination));
                     }
                 }
@@ -131,7 +140,7 @@ impl SimElement for Node {
                     let routed_rpcs = self.route_rpc(inbound_rpc.0);
                     for routed_rpc in routed_rpcs {
                         self.enqueue(
-                        RpcWithDst {
+                            RpcWithDst {
                                 rpc: routed_rpc.rpc,
                                 destination: routed_rpc.destination,
                             },

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -87,8 +87,6 @@ impl SimElement for Node {
                     ret.push((rpc_dst.rpc, rpc_dst.destination));
                 }
             }
-
-            // 2. send it off
         }
 
         ret

--- a/libs/sim/plugin_wrapper.rs
+++ b/libs/sim/plugin_wrapper.rs
@@ -37,7 +37,7 @@ impl fmt::Display for PluginWrapper {
 }
 
 impl SimElement for PluginWrapper {
-    fn tick(&mut self, _tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, _tick: u64) -> Vec<Rpc> {
         let mut to_return = vec![];
         while !self.stored_rpc.is_empty() {
             let input_rpc = self.stored_rpc.pop();
@@ -45,7 +45,7 @@ impl SimElement for PluginWrapper {
             if ret.len() > 0 {
                 for rpc in ret {
                     if self.neighbor.len() > 0 {
-                        to_return.push((rpc, self.neighbor[0].clone()));
+                        to_return.push(rpc);
                     }
                 }
             }

--- a/libs/sim/sim_element.rs
+++ b/libs/sim/sim_element.rs
@@ -7,7 +7,7 @@ use rpc_lib::rpc::Rpc;
 pub trait SimElement {
     fn add_connection(&mut self, neighbor: String);
 
-    fn tick(&mut self, tick: u64) -> Vec<(Rpc, String)>;
+    fn tick(&mut self, tick: u64) -> Vec<Rpc>;
 
     fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
 

--- a/libs/sim/simulator.rs
+++ b/libs/sim/simulator.rs
@@ -142,8 +142,8 @@ impl Simulator {
         for (elem_name, element_obj) in self.elements.iter_mut() {
             let rpcs = element_obj.tick(tick);
             let mut input_rpcs = vec![];
-            for (rpc, dst) in rpcs {
-                input_rpcs.push((rpc, dst));
+            for rpc in rpcs {
+                input_rpcs.push(rpc);
             }
             rpc_buffer.insert(elem_name.clone(), input_rpcs);
             if !elem_name.contains("_") {
@@ -156,11 +156,12 @@ impl Simulator {
         print!("\n\n");
 
         // now start the receive phase
-        for (elem_name, rpc_tuples) in rpc_buffer {
-            for (rpc, dst) in rpc_tuples {
-                match self.elements.get_mut(&dst) {
+        for (elem_name, rpcs) in rpc_buffer {
+            for rpc in rpcs {
+                let dst = &rpc.headers["dest"];
+                match self.elements.get_mut(dst) {
                     Some(elem) => elem.recv(rpc, tick, &elem_name),
-                    None => panic!("expected {0} to be in elements, but it was not", &dst),
+                    None => panic!("expected {0} to be in elements, but it was not", dst),
                 }
             }
         }

--- a/libs/sim/storage.rs
+++ b/libs/sim/storage.rs
@@ -30,7 +30,7 @@ impl fmt::Display for Storage {
 
 impl SimElement for Storage {
     // storage never sends messages out, only receives them, so we return an empty vector
-    fn tick(&mut self, _tick: u64) -> Vec<(Rpc, String)> {
+    fn tick(&mut self, _tick: u64) -> Vec<Rpc> {
         return vec![];
     }
 


### PR DESCRIPTION
Before, filters would only execute once, just before we sent the response out.  Now, in the recv function for all nodes, the rpcs get filtered once as "ingress", get routed to their next stop, and then are filtered again as "egress".  So the queue stored in the node itself is really an outgoing queue.