### PR TITLE
Cleanup

### DIFF
--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -38,7 +38,7 @@ impl SimElement for Gateway {
         }
         ret
     }
-    fn recv(&mut self, _rpc: Rpc, _tick: u64, _sender: &str) {
+    fn recv(&mut self, _rpc: Rpc, _tick: u64) {
         // we discard anything we receive
     }
     fn add_connection(&mut self, neighbor: String) {
@@ -85,10 +85,10 @@ mod tests {
         node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
         node.core_node.tick(0);
         assert!(node.core_node.queue.size() == 1);

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -39,8 +39,10 @@ impl SimElement for LeafNode {
             self.process_rpc(&mut rpc, &mut new_rpcs);
 
             // Pass the RPCs we have through the plugin
-            self.core_node
-                .pass_through_plugin(new_rpcs, &mut outgoing_rpcs, tick, "egress");
+            for rpc in new_rpcs {
+                self.core_node
+                    .pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+            }
         }
         outgoing_rpcs
     }

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -38,22 +38,14 @@ impl SimElement for LeafNode {
             if !rpc.headers.contains_key("src") {
                 panic!("Leaf node is missing source header for forwarding! Invalid RPC.");
             }
-            self.choose_destination(&mut rpc);
-
-            // This turns into a response now
-            rpc.headers
-                .insert("direction".to_string(), "response".to_string());
-
-            // Update the source after we have chosen the destination
-            rpc.headers
-                .insert("src".to_string(), self.core_node.id.to_string());
+            self.process_rpc(&mut rpc);
 
             // If the plugin exists, run the RPC through
             // Otherwise just push it into the egress queue
             if let Some(plugin) = self.core_node.plugin.as_mut() {
                 rpc.headers
                     .insert("location".to_string(), "egress".to_string());
-                plugin.recv(rpc, tick, &self.core_node.id);
+                plugin.recv(rpc, tick);
                 let filtered_rpcs = plugin.tick(tick);
                 for filtered_rpc in filtered_rpcs {
                     outgoing_rpcs.push(filtered_rpc.clone());
@@ -64,8 +56,8 @@ impl SimElement for LeafNode {
         }
         outgoing_rpcs
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str) {
-        self.core_node.recv(rpc, tick, sender);
+    fn recv(&mut self, rpc: Rpc, tick: u64) {
+        self.core_node.recv(rpc, tick);
     }
     fn add_connection(&mut self, neighbor: String) {
         self.core_node.add_connection(neighbor)
@@ -89,10 +81,17 @@ impl LeafNode {
         LeafNode { core_node }
     }
 
-    pub fn choose_destination(&mut self, rpc: &mut Rpc) {
+    pub fn process_rpc(&mut self, rpc: &mut Rpc) {
         // We just reflect the RPC
         rpc.headers
             .insert("dest".to_string(), rpc.headers["src"].to_string());
+        // This turns into a response now
+        rpc.headers
+            .insert("direction".to_string(), "response".to_string());
+
+        // Update the source after we have chosen the destination
+        rpc.headers
+            .insert("src".to_string(), self.core_node.id.to_string());
     }
 }
 
@@ -112,10 +111,10 @@ mod tests {
         node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
         node.core_node.tick(0);
         assert!(node.core_node.queue.size() == 1);

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -40,8 +40,10 @@ impl SimElement for ProductPage {
             self.process_rpc(&mut rpc, &mut new_rpcs);
 
             // Pass the RPCs we have through the plugin
-            self.core_node
-                .pass_through_plugin(new_rpcs, &mut outgoing_rpcs, tick, "egress");
+            for rpc in new_rpcs {
+                self.core_node
+                    .pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+            }
         }
         outgoing_rpcs
     }

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -41,8 +41,10 @@ impl SimElement for Reviews {
             self.process_rpc(&mut rpc, &mut new_rpcs);
 
             // Pass the rpc we have through the plugin
-            self.core_node
-                .pass_through_plugin(new_rpcs, &mut outgoing_rpcs, tick, "egress");
+            for rpc in new_rpcs {
+                self.core_node
+                    .pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+            }
         }
         outgoing_rpcs
     }

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -44,7 +44,7 @@ impl SimElement for Reviews {
             if let Some(plugin) = self.core_node.plugin.as_mut() {
                 rpc.headers
                     .insert("location".to_string(), "egress".to_string());
-                plugin.recv(rpc, tick, &self.core_node.id);
+                plugin.recv(rpc, tick);
                 let filtered_rpcs = plugin.tick(tick);
                 for filtered_rpc in filtered_rpcs {
                     outgoing_rpcs.push(filtered_rpc.clone());
@@ -55,8 +55,8 @@ impl SimElement for Reviews {
         }
         outgoing_rpcs
     }
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str) {
-        self.core_node.recv(rpc, tick, sender);
+    fn recv(&mut self, rpc: Rpc, tick: u64) {
+        self.core_node.recv(rpc, tick);
     }
     fn add_connection(&mut self, neighbor: String) {
         self.core_node.add_connection(neighbor)
@@ -112,10 +112,10 @@ mod tests {
         node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0, "0");
+        node.core_node.recv(Rpc::new_rpc("0"), 0);
         assert!(node.core_node.queue.size() == 2);
         node.core_node.tick(0);
         assert!(node.core_node.queue.size() == 1);

--- a/libs/sim/plugin_wrapper.rs
+++ b/libs/sim/plugin_wrapper.rs
@@ -52,7 +52,7 @@ impl SimElement for PluginWrapper {
         }
         return to_return;
     }
-    fn recv(&mut self, rpc: Rpc, _tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: Rpc, _tick: u64) {
         self.stored_rpc.push(rpc);
     }
     fn add_connection(&mut self, neighbor: String) {

--- a/libs/sim/sim_element.rs
+++ b/libs/sim/sim_element.rs
@@ -9,7 +9,7 @@ pub trait SimElement {
 
     fn tick(&mut self, tick: u64) -> Vec<Rpc>;
 
-    fn recv(&mut self, rpc: Rpc, tick: u64, sender: &str);
+    fn recv(&mut self, rpc: Rpc, tick: u64);
 
     fn whoami(&self) -> &str;
 

--- a/libs/sim/sim_element.rs
+++ b/libs/sim/sim_element.rs
@@ -17,5 +17,3 @@ pub trait SimElement {
 
     fn as_any(&self) -> &dyn Any;
 }
-
-pub trait Node {}

--- a/libs/sim/simulator.rs
+++ b/libs/sim/simulator.rs
@@ -160,7 +160,7 @@ impl Simulator {
             for rpc in rpcs {
                 let dst = &rpc.headers["dest"];
                 match self.elements.get_mut(dst) {
-                    Some(elem) => elem.recv(rpc, tick, &elem_name),
+                    Some(elem) => elem.recv(rpc, tick),
                     None => panic!("expected {0} to be in elements, but it was not", dst),
                 }
             }

--- a/libs/sim/simulator.rs
+++ b/libs/sim/simulator.rs
@@ -136,33 +136,29 @@ impl Simulator {
     }
 
     pub fn tick(&mut self, tick: u64) {
-        let mut rpc_buffer = HashMap::new();
+        let mut rpc_buffer = vec![];
         // tick all elements to generate Rpcs
         // this is the send phase. collect all the rpcs
         for (elem_name, element_obj) in self.elements.iter_mut() {
             let rpcs = element_obj.tick(tick);
-            let mut input_rpcs = vec![];
-            for rpc in rpcs {
-                input_rpcs.push(rpc);
+            for rpc in &rpcs {
+                rpc_buffer.push(rpc.clone());
             }
-            rpc_buffer.insert(elem_name.clone(), input_rpcs);
             if !elem_name.contains("_") {
                 println!(
                     "After tick {:5}, {:45} \n\toutputs {:?}\n",
-                    tick, element_obj, rpc_buffer[elem_name]
+                    tick, element_obj, rpcs
                 );
             }
         }
         print!("\n\n");
 
         // now start the receive phase
-        for (elem_name, rpcs) in rpc_buffer {
-            for rpc in rpcs {
-                let dst = &rpc.headers["dest"];
-                match self.elements.get_mut(dst) {
-                    Some(elem) => elem.recv(rpc, tick),
-                    None => panic!("expected {0} to be in elements, but it was not", dst),
-                }
+        for rpc in rpc_buffer {
+            let dst = &rpc.headers["dest"];
+            match self.elements.get_mut(dst) {
+                Some(elem) => elem.recv(rpc, tick),
+                None => panic!("expected {0} to be in elements, but it was not", dst),
             }
         }
 

--- a/libs/sim/storage.rs
+++ b/libs/sim/storage.rs
@@ -34,7 +34,7 @@ impl SimElement for Storage {
         return vec![];
     }
 
-    fn recv(&mut self, rpc: Rpc, tick: u64, _sender: &str) {
+    fn recv(&mut self, rpc: Rpc, tick: u64) {
         self.store(rpc, tick);
     }
     fn add_connection(&mut self, neighbor: String) {
@@ -86,7 +86,7 @@ mod tests {
         let mut rpc = Rpc::new_rpc("0");
         rpc.headers
             .insert("dest".to_string(), "storage".to_string());
-        storage.recv(rpc, 0, "node");
+        storage.recv(rpc, 0);
         let ret = storage.query();
         assert!(ret == "0\n".to_string());
     }


### PR DESCRIPTION
Cleaned up the bookinfo app and the simulator a little after the recent changes. The are now three stages to each node: 
For example, productpage:
```Rust
if self.core_node.queue.size() == 0 {
    // No RPC in the queue. We only forward, so nothing to do
    continue;
}
let mut rpc = self.core_node.dequeue(tick).unwrap();
// Forward requests/responses from productpage or reviews
if !rpc.headers.contains_key("src") {
    panic!("Product page got rpc without a source");
}
// Process the RPC
let mut new_rpcs: Vec<Rpc> = vec![];
self.process_rpc(&mut rpc, &mut new_rpcs);

// Pass the RPCs we have through the plugin
self.core_node
    .pass_through_plugin(new_rpcs, &mut outgoing_rpcs, tick, "egress");
```
First preprocess, then do some custom processing on the received RPC, that may generate new RPCs. Receive these RPCs, and feed them through the plugin. This structure is the same for all nodes.
Also took the liberty to rename the function to process_rpc since it does more than just returning destination. Feel free to suggest better alternatives on how to structure this.