### PR TITLE
Changed bookinfo so that rpcs sent to storage are processed instead o…

### DIFF
--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -66,15 +66,17 @@ impl SimElement for LeafNode {
 
 impl NodeTraits for LeafNode {
     fn process_rpc(&self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
-        // We just reflect the RPC
-        rpc.headers
-            .insert("dest".to_string(), rpc.headers["src"].to_string());
-        // This turns into a response now
-        rpc.headers
-            .insert("direction".to_string(), "response".to_string());
-        // Update the source after we have chosen the destination
-        rpc.headers
-            .insert("src".to_string(), self.core_node.id.to_string());
+        if !rpc.headers["dest"].contains("storage") {
+            // We just reflect the RPC
+            rpc.headers
+                .insert("dest".to_string(), rpc.headers["src"].to_string());
+            // This turns into a response now
+            rpc.headers
+                .insert("direction".to_string(), "response".to_string());
+            // Update the source after we have chosen the destination
+            rpc.headers
+                .insert("src".to_string(), self.core_node.id.to_string());
+        }
         new_rpcs.push(rpc.clone());
     }
 }

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -85,7 +85,7 @@ impl NodeTraits for ProductPage {
                 .headers
                 .insert("src".to_string(), self.core_node.id.to_string());
             new_rpcs.push(details_rpc);
-        } else {
+        } else if !&rpc.headers["dest"].contains("storage") {
             panic!("ProductPage node does not have a valid source!");
         }
         rpc.headers

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -75,7 +75,7 @@ impl NodeTraits for Reviews {
         } else if source == "productpage-v1" {
             rpc.headers
                 .insert("dest".to_string(), "ratings-v1".to_string());
-        } else {
+        } else if !&rpc.headers["dest"].contains("storage") {
             panic!("Unexpected RPC source {:?}", source);
         }
         rpc.headers

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -257,6 +257,14 @@ mod tests {
         assert!(graph.node_count() == 0);
     }
 
+    fn test_generate_trace_graph_from_headers_on_small_string() {
+        let graph = generate_trace_graph_from_headers(
+            "productpage-v1,details-v1,productpage-v1".to_string(),
+            String::new(),
+        );
+        assert!(graph.node_count() == 3);
+    }
+
     #[test]
     fn test_get_tree_height() {
         let graph = generate_trace_graph_from_headers("0,1,3,1,2".to_string(), String::new());


### PR DESCRIPTION
…f causing panics, also added a test for graph_utils

The main issue was that if the source wasn't from a certain list, we thought it was an error and panicked.  However, the filter edits src/dest in order to send rpcs to storage.  So I made extra checks ignoring our routing rules for rpcs destined for storage.