### PR TITLE
Product page now merges rpcs properly

### DIFF
--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -21,7 +21,6 @@ impl fmt::Display for Gateway {
 impl SimElement for Gateway {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut outbound_rpcs = self.core_node.tick(tick);
-        println!("{:?}", outbound_rpcs);
         for outbound_rpc in &mut outbound_rpcs {
             outbound_rpc
                 .headers

--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -6,7 +6,6 @@ use rpc_lib::rpc::Rpc;
 use sim::node::node_fmt_with_name;
 use sim::node::Node;
 use sim::sim_element::SimElement;
-use std::cmp::min;
 use std::fmt;
 
 pub struct Gateway {
@@ -21,22 +20,20 @@ impl fmt::Display for Gateway {
 
 impl SimElement for Gateway {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        let mut ret = vec![];
-        for _ in 0..min(
-            self.core_node.generation_rate as usize,
-            self.core_node.egress_rate as usize,
-        ) {
-            let mut rpc: Rpc;
-            rpc = Rpc::new_rpc(&tick.to_string());
-            rpc.headers
+        let mut outbound_rpcs = self.core_node.tick(tick);
+        println!("{:?}", outbound_rpcs);
+        for outbound_rpc in &mut outbound_rpcs {
+            outbound_rpc
+                .headers
                 .insert("direction".to_string(), "request".to_string());
-            rpc.headers
+            outbound_rpc
+                .headers
                 .insert("src".to_string(), self.core_node.id.to_string());
-            rpc.headers
+            outbound_rpc
+                .headers
                 .insert("dest".to_string(), "productpage-v1".to_string());
-            ret.push(rpc);
         }
-        ret
+        outbound_rpcs
     }
     fn recv(&mut self, _rpc: Rpc, _tick: u64) {
         // we discard anything we receive
@@ -82,15 +79,28 @@ mod tests {
     #[test]
     fn test_node_capacity_and_egress_rate() {
         let mut node = Gateway::new("0", 2, 1, 0, 1);
-        node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
+        // without at least one neighbor, it will just drop rpcs
+        node.add_connection("foo".to_string());
+        let mut queue_size: usize;
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.tick(0);
-        assert!(node.core_node.ingress_queue.size() == 1);
+        node.core_node.enqueue_ingress(Rpc::new_rpc("0"), 0);
+        node.core_node.enqueue_ingress(Rpc::new_rpc("0"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        node.recv(Rpc::new_rpc("0"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        let outbound_rpcs = node.tick(0);
+        queue_size = node.core_node.egress_queue.size();
+        assert!(outbound_rpcs.len() == 1, "Queue size was `{}`", queue_size);
     }
 }

--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -84,15 +84,15 @@ mod tests {
         let mut queue_size: usize;
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.enqueue_ingress(Rpc::new_rpc("0"), 0);
-        node.core_node.enqueue_ingress(Rpc::new_rpc("0"), 0);
+        node.core_node.enqueue_ingress(Rpc::new("0"), 0);
+        node.core_node.enqueue_ingress(Rpc::new("0"), 0);
         queue_size = node.core_node.ingress_queue.size();
         assert!(
             node.core_node.ingress_queue.size() == 2,
             "Queue size was `{}`",
             queue_size
         );
-        node.recv(Rpc::new_rpc("0"), 0);
+        node.recv(Rpc::new("0"), 0);
         queue_size = node.core_node.ingress_queue.size();
         assert!(
             node.core_node.ingress_queue.size() == 2,

--- a/example_envs/bookinfo/gateway.rs
+++ b/example_envs/bookinfo/gateway.rs
@@ -87,10 +87,10 @@ mod tests {
         assert!(node.core_node.egress_rate == 1);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.tick(0);
-        assert!(node.core_node.queue.size() == 1);
+        assert!(node.core_node.ingress_queue.size() == 1);
     }
 }

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -22,14 +22,14 @@ impl SimElement for LeafNode {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut outgoing_rpcs: Vec<Rpc> = vec![];
         for _ in 0..min(
-            self.core_node.queue.size(),
+            self.core_node.ingress_queue.size(),
             self.core_node.egress_rate as usize,
         ) {
-            if self.core_node.queue.size() == 0 {
+            if self.core_node.ingress_queue.size() == 0 {
                 // No RPC in the queue. We only react, so nothing to do
                 continue;
             }
-            let mut rpc = self.core_node.dequeue(tick).unwrap();
+            let mut rpc = self.core_node.dequeue_ingress(tick).unwrap();
 
             if !rpc.headers.contains_key("src") {
                 panic!("Leaf node is missing source header for forwarding! Invalid RPC.");
@@ -105,11 +105,11 @@ mod tests {
         assert!(node.core_node.egress_rate == 1);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.tick(0);
-        assert!(node.core_node.queue.size() == 1);
+        assert!(node.core_node.ingress_queue.size() == 1);
     }
 
     #[test]

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -20,19 +20,10 @@ impl fmt::Display for LeafNode {
 
 impl SimElement for LeafNode {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        let mut outgoing_rpcs: Vec<Rpc> = vec![];
-        for _ in 0..min(
-            self.core_node.ingress_queue.size(),
-            self.core_node.egress_rate as usize,
-        ) {
-            if self.core_node.ingress_queue.size() == 0 {
-                // No RPC in the queue. We only react, so nothing to do
-                continue;
-            }
-            let mut rpc = self.core_node.dequeue_ingress(tick).unwrap();
-
+        if let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
+            let mut queued_rpcs: Vec<Rpc> = vec![];
             if !rpc.headers.contains_key("src") {
-                panic!("Leaf node is missing source header for forwarding! Invalid RPC.");
+                panic!("Leaf node received an RPC without a source");
             }
             // Process the RPC
             let mut new_rpcs: Vec<Rpc> = vec![];
@@ -41,10 +32,22 @@ impl SimElement for LeafNode {
             // Pass the RPCs we have through the plugin
             for rpc in new_rpcs {
                 self.core_node
-                    .pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+                    .pass_through_plugin(rpc, &mut queued_rpcs, tick, "egress");
+            }
+            for queued_rpcs in &queued_rpcs {
+                self.core_node.enqueue_egress(queued_rpcs.clone())
             }
         }
-        outgoing_rpcs
+
+        let max_output = min(
+            self.core_node.egress_queue.size(),
+            self.core_node.egress_rate as usize,
+        );
+        let mut outbound_rpcs: Vec<Rpc> = vec![];
+        for _ in 0..max_output {
+            outbound_rpcs.push(self.core_node.dequeue_egress().unwrap())
+        }
+        outbound_rpcs
     }
     fn recv(&mut self, rpc: Rpc, tick: u64) {
         self.core_node.recv(rpc, tick);
@@ -100,16 +103,29 @@ mod tests {
     #[test]
     fn test_node_capacity_and_egress_rate() {
         let mut node = LeafNode::new("0", 2, 1, None);
-        node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
+        // without at least one neighbor, it will just drop rpcs
+        node.add_connection("foo".to_string());
+        let mut queue_size: usize;
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.tick(0);
-        assert!(node.core_node.ingress_queue.size() == 1);
+        node.recv(Rpc::new_with_src("0", "gateway"), 0);
+        node.recv(Rpc::new_with_src("0", "gateway"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        node.recv(Rpc::new_with_src("0", "gateway"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        node.tick(0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(queue_size == 1, "Queue size was `{}`", queue_size);
     }
 
     #[test]

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -65,7 +65,7 @@ impl SimElement for LeafNode {
 }
 
 impl NodeTraits for LeafNode {
-    fn process_rpc(&self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
+    fn process_rpc(&mut self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
         // We just reflect the RPC
         rpc.headers
             .insert("dest".to_string(), rpc.headers["src"].to_string());

--- a/example_envs/bookinfo/leafnode.rs
+++ b/example_envs/bookinfo/leafnode.rs
@@ -20,7 +20,7 @@ impl fmt::Display for LeafNode {
 
 impl SimElement for LeafNode {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        if let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
+        while let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
             let mut queued_rpcs: Vec<Rpc> = vec![];
             if !rpc.headers.contains_key("src") {
                 panic!("Leaf node received an RPC without a source");
@@ -124,7 +124,7 @@ mod tests {
             queue_size
         );
         node.tick(0);
-        queue_size = node.core_node.ingress_queue.size();
+        queue_size = node.core_node.egress_queue.size();
         assert!(queue_size == 1, "Queue size was `{}`", queue_size);
     }
 

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -37,7 +37,7 @@ impl fmt::Display for ProductPage {
 
 impl SimElement for ProductPage {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        if let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
+        while let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
             let mut queued_rpcs: Vec<Rpc> = vec![];
             // Forward requests/responses from productpage or reviews
             if !rpc.headers.contains_key("src") {
@@ -218,8 +218,8 @@ mod tests {
             queue_size
         );
         node.tick(0);
-        queue_size = node.core_node.ingress_queue.size();
-        assert!(queue_size == 1, "Queue size was `{}`", queue_size);
+        queue_size = node.core_node.egress_queue.size();
+        assert!(queue_size == 3, "Queue size was `{}`", queue_size);
     }
 
     #[test]

--- a/example_envs/bookinfo/productpage.rs
+++ b/example_envs/bookinfo/productpage.rs
@@ -161,7 +161,7 @@ impl ProductPage {
             pending_rpc.reviews_reply = Some(inbound_rpc);
         }
         if pending_rpc.details_reply.is_some() && pending_rpc.reviews_reply.is_some() {
-            let mut merged_rpc = Rpc::new_rpc("response");
+            let mut merged_rpc = Rpc::new("response");
             merged_rpc
                 .headers
                 .insert("direction".to_string(), "response".to_string());

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -22,12 +22,12 @@ impl SimElement for Reviews {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
         let mut outgoing_rpcs: Vec<Rpc> = vec![];
         for _ in 0..min(
-            self.core_node.queue.size(),
+            self.core_node.ingress_queue.size(),
             self.core_node.egress_rate as usize,
         ) {
             let mut rpc: Rpc;
-            if self.core_node.queue.size() > 0 {
-                let deq = self.core_node.dequeue(tick);
+            if self.core_node.ingress_queue.size() > 0 {
+                let deq = self.core_node.dequeue_ingress(tick);
                 rpc = deq.unwrap();
             } else {
                 // no rpc in the queue, we only forward so nothing to do
@@ -109,11 +109,11 @@ mod tests {
         assert!(node.core_node.egress_rate == 1);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.queue.size() == 2);
+        assert!(node.core_node.ingress_queue.size() == 2);
         node.core_node.tick(0);
-        assert!(node.core_node.queue.size() == 1);
+        assert!(node.core_node.ingress_queue.size() == 1);
     }
 
     #[test]

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -20,7 +20,7 @@ impl fmt::Display for Reviews {
 
 impl SimElement for Reviews {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        if let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
+        while let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
             let mut queued_rpcs: Vec<Rpc> = vec![];
             if !rpc.headers.contains_key("src") {
                 panic!("Reviews received an RPC without a source");
@@ -111,14 +111,14 @@ mod tests {
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
         node.recv(Rpc::new_with_src("0", "ratings-v1"), 0);
-        node.recv(Rpc::new_with_src("0", "productpage"), 0);
+        node.recv(Rpc::new_with_src("0", "productpage-v1"), 0);
         queue_size = node.core_node.ingress_queue.size();
         assert!(
             node.core_node.ingress_queue.size() == 2,
             "Queue size was `{}`",
             queue_size
         );
-        node.recv(Rpc::new_with_src("0", "productpage"), 0);
+        node.recv(Rpc::new_with_src("0", "productpage-v1"), 0);
         queue_size = node.core_node.ingress_queue.size();
         assert!(
             node.core_node.ingress_queue.size() == 2,
@@ -126,7 +126,7 @@ mod tests {
             queue_size
         );
         node.tick(0);
-        queue_size = node.core_node.ingress_queue.size();
+        queue_size = node.core_node.egress_queue.size();
         assert!(queue_size == 1, "Queue size was `{}`", queue_size);
     }
 

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -67,7 +67,7 @@ impl SimElement for Reviews {
 }
 
 impl NodeTraits for Reviews {
-    fn process_rpc(&self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
+    fn process_rpc(&mut self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
         let source = &rpc.headers["src"];
         if source == "ratings-v1" {
             rpc.headers

--- a/example_envs/bookinfo/reviews.rs
+++ b/example_envs/bookinfo/reviews.rs
@@ -20,33 +20,34 @@ impl fmt::Display for Reviews {
 
 impl SimElement for Reviews {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        let mut outgoing_rpcs: Vec<Rpc> = vec![];
-        for _ in 0..min(
-            self.core_node.ingress_queue.size(),
-            self.core_node.egress_rate as usize,
-        ) {
-            let mut rpc: Rpc;
-            if self.core_node.ingress_queue.size() > 0 {
-                let deq = self.core_node.dequeue_ingress(tick);
-                rpc = deq.unwrap();
-            } else {
-                // no rpc in the queue, we only forward so nothing to do
-                continue;
-            }
+        if let Some(mut rpc) = self.core_node.dequeue_ingress(tick) {
+            let mut queued_rpcs: Vec<Rpc> = vec![];
             if !rpc.headers.contains_key("src") {
-                panic!("Reviews node is missing source header for forwarding! Invalid RPC.");
+                panic!("Reviews received an RPC without a source");
             }
             // Process the RPC
             let mut new_rpcs: Vec<Rpc> = vec![];
             self.process_rpc(&mut rpc, &mut new_rpcs);
 
-            // Pass the rpc we have through the plugin
+            // Pass the RPCs we have through the plugin
             for rpc in new_rpcs {
                 self.core_node
-                    .pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+                    .pass_through_plugin(rpc, &mut queued_rpcs, tick, "egress");
+            }
+            for queued_rpcs in &queued_rpcs {
+                self.core_node.enqueue_egress(queued_rpcs.clone())
             }
         }
-        outgoing_rpcs
+
+        let max_output = min(
+            self.core_node.egress_queue.size(),
+            self.core_node.egress_rate as usize,
+        );
+        let mut outbound_rpcs: Vec<Rpc> = vec![];
+        for _ in 0..max_output {
+            outbound_rpcs.push(self.core_node.dequeue_egress().unwrap())
+        }
+        outbound_rpcs
     }
     fn recv(&mut self, rpc: Rpc, tick: u64) {
         self.core_node.recv(rpc, tick);
@@ -104,16 +105,29 @@ mod tests {
     #[test]
     fn test_node_capacity_and_egress_rate() {
         let mut node = Reviews::new("0", 2, 1, None);
-        node.add_connection("foo".to_string()); // without at least one neighbor, it will just drop rpcs
+        // without at least one neighbor, it will just drop rpcs
+        node.add_connection("foo".to_string());
+        let mut queue_size: usize;
         assert!(node.core_node.capacity == 2);
         assert!(node.core_node.egress_rate == 1);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.core_node.ingress_queue.size() == 2);
-        node.core_node.tick(0);
-        assert!(node.core_node.ingress_queue.size() == 1);
+        node.recv(Rpc::new_with_src("0", "ratings-v1"), 0);
+        node.recv(Rpc::new_with_src("0", "productpage"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        node.recv(Rpc::new_with_src("0", "productpage"), 0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(
+            node.core_node.ingress_queue.size() == 2,
+            "Queue size was `{}`",
+            queue_size
+        );
+        node.tick(0);
+        queue_size = node.core_node.ingress_queue.size();
+        assert!(queue_size == 1, "Queue size was `{}`", queue_size);
     }
 
     #[test]

--- a/libs/filter_example/src/example_filter.rs
+++ b/libs/filter_example/src/example_filter.rs
@@ -60,7 +60,6 @@ impl Filter {
         let rpc_to_return = Rpc {
             data: x.data.clone(),
             uid: x.uid,
-            path: x.path.clone(),
             headers: x.headers.clone(),
         };
         let mut to_return = vec![rpc_to_return];
@@ -211,7 +210,7 @@ impl Filter {
             let trace_graph;
             if x.headers.contains_key(&"properties".to_string()) {
                 trace_graph = graph_utils::generate_trace_graph_from_headers(
-                    x.path.clone(),
+                    "".to_string(),
                     mod_rpc
                         .headers
                         .get_mut(&"properties".to_string())
@@ -219,8 +218,10 @@ impl Filter {
                         .to_string(),
                 );
             } else {
-                trace_graph =
-                    graph_utils::generate_trace_graph_from_headers(x.path.clone(), String::new());
+                trace_graph = graph_utils::generate_trace_graph_from_headers(
+                    "".to_string(),
+                    String::new(),
+                );
             }
             let mapping = isomorphic_subgraph_matching(
                 &target_graph,

--- a/libs/filter_example/src/example_filter.rs
+++ b/libs/filter_example/src/example_filter.rs
@@ -250,7 +250,7 @@ impl Filter {
                     &trace_graph.node_weight(trace_node_index).unwrap().1
                         [&vec!["response", "total_size"].join(".")];
 
-                let mut result_rpc = Rpc::new_rpc(a_response_total_size_str);
+                let mut result_rpc = Rpc::new(a_response_total_size_str);
                 result_rpc
                     .headers
                     .insert("dest".to_string(), "storage".to_string());

--- a/libs/filter_example/src/example_filter.rs
+++ b/libs/filter_example/src/example_filter.rs
@@ -218,10 +218,8 @@ impl Filter {
                         .to_string(),
                 );
             } else {
-                trace_graph = graph_utils::generate_trace_graph_from_headers(
-                    "".to_string(),
-                    String::new(),
-                );
+                trace_graph =
+                    graph_utils::generate_trace_graph_from_headers("".to_string(), String::new());
             }
             let mapping = isomorphic_subgraph_matching(
                 &target_graph,

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -286,4 +286,14 @@ mod tests {
         let ret = get_node_with_id(&graph, "0".to_string()).unwrap();
         assert!(graph.node_weight(ret).unwrap().1[&"property".to_string()] == "thing");
     }
+
+    // #[test]
+    // fn test_generate_trace_graph_from_headers_on_small_string() {
+    //     let graph = generate_trace_graph_from_headers(
+    //         "productpage-v1,details-v1,productpage-v1".to_string(),
+    //         String::new(),
+    //     );
+    //     let node_count = graph.node_count();
+    //     assert!(graph.node_count() == 3, "Graph node count `{}`", node_count);
+    // }
 }

--- a/libs/rpc_lib/src/rpc.rs
+++ b/libs/rpc_lib/src/rpc.rs
@@ -36,5 +36,4 @@ impl Rpc {
         rpc.headers.insert("dst".to_string(), dst.to_string());
         rpc
     }
-
 }

--- a/libs/rpc_lib/src/rpc.rs
+++ b/libs/rpc_lib/src/rpc.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 pub struct Rpc {
     pub data: String,                     // application data
     pub uid: u64,                         // number of hops the message has taken
-    pub path: String,                     // the path that the request has taken thus far
     pub headers: HashMap<String, String>, // the "http" headers of the rpc, ie, filter-defined book keeping
 }
 
@@ -16,7 +15,6 @@ impl Rpc {
             Rpc {
                 data: data.to_string(),
                 uid: COUNTER,
-                path: String::new(),
                 headers: HashMap::new(),
             }
         };
@@ -25,8 +23,18 @@ impl Rpc {
         }
         ret
     }
-    pub fn add_to_path(&mut self, hop: &str) {
-        self.path.push(' ');
-        self.path.push_str(hop);
+
+    pub fn new_with_src(data: &str, src: &str) -> Self {
+        let mut rpc = Rpc::new_rpc(data);
+        rpc.headers.insert("src".to_string(), src.to_string());
+        rpc
     }
+
+    pub fn new_with_src_dest(data: &str, src: &str, dst: &str) -> Self {
+        let mut rpc = Rpc::new_rpc(data);
+        rpc.headers.insert("src".to_string(), src.to_string());
+        rpc.headers.insert("dst".to_string(), dst.to_string());
+        rpc
+    }
+
 }

--- a/libs/rpc_lib/src/rpc.rs
+++ b/libs/rpc_lib/src/rpc.rs
@@ -9,7 +9,7 @@ pub struct Rpc {
 }
 
 impl Rpc {
-    pub fn new_rpc(data: &str) -> Self {
+    pub fn new(data: &str) -> Self {
         static mut COUNTER: u64 = 0;
         let ret = unsafe {
             Rpc {
@@ -25,13 +25,13 @@ impl Rpc {
     }
 
     pub fn new_with_src(data: &str, src: &str) -> Self {
-        let mut rpc = Rpc::new_rpc(data);
+        let mut rpc = Rpc::new(data);
         rpc.headers.insert("src".to_string(), src.to_string());
         rpc
     }
 
     pub fn new_with_src_dest(data: &str, src: &str, dst: &str) -> Self {
-        let mut rpc = Rpc::new_rpc(data);
+        let mut rpc = Rpc::new(data);
         rpc.headers.insert("src".to_string(), src.to_string());
         rpc.headers.insert("dst".to_string(), dst.to_string());
         rpc

--- a/libs/sim/edge.rs
+++ b/libs/sim/edge.rs
@@ -151,7 +151,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc("0"), i)
+                edge.enqueue(Rpc::new("0"), i)
             }
         });
     }
@@ -161,7 +161,7 @@ mod tests {
         let mut edge = Edge::new("0", 0);
         b.iter(|| {
             for i in 1..100 {
-                edge.enqueue(Rpc::new_rpc("0"), i);
+                edge.enqueue(Rpc::new("0"), i);
             }
             edge.dequeue(0);
         });

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -11,7 +11,8 @@ use std::cmp::min;
 use std::fmt;
 
 pub struct Node {
-    pub queue: Queue<Rpc>,             // queue of rpcs
+    pub ingress_queue: Queue<Rpc>,     // queue of incoming rpcs
+    pub egress_queue: Queue<Rpc>,      // queue of outgoing rpcs
     pub id: String,                    // id of the node
     pub capacity: u32,                 // capacity of the node;  how much it can hold at once
     pub egress_rate: u32,              // rate at which the node can send out rpcs
@@ -30,18 +31,18 @@ pub fn node_fmt_with_name(node: &Node, f: &mut fmt::Formatter<'_>, name: &str) -
         if node.plugin.is_none() {
             write!(f, "{:width$}",
                        &format!("{} {{ id : {}, capacity : {}, egress_rate : {}, generation_rate : {}, queue: {}, plugin : None}}", name,
-                       &node.id, &node.capacity, &node.egress_rate, &node.generation_rate, &node.queue.size()),
+                       &node.id, &node.capacity, &node.egress_rate, &node.generation_rate, &node.ingress_queue.size()),
                        width = width)
         } else {
             write!(f, "{:width$}",
                        &format!("{} {{ id : {}, capacity : {}, egress_rate : {}, generation_rate : {}, queue : {}, \n\tplugin : {} }}", name,
-                       &node.id, &node.capacity, &node.egress_rate, &node.generation_rate, &node.queue.size(), node.plugin.as_ref().unwrap()),
+                       &node.id, &node.capacity, &node.egress_rate, &node.generation_rate, &node.ingress_queue.size(), node.plugin.as_ref().unwrap()),
                        width = width)
         }
     } else {
         if node.plugin.is_none() {
             write!(f, "{} {{ id : {}, egress_rate : {}, generation_rate : {}, plugin : None, capacity : {}, queue : {} }}",
-                        name,&node.id, &node.egress_rate, &node.generation_rate, &node.capacity, &node.queue.size())
+                        name,&node.id, &node.egress_rate, &node.generation_rate, &node.capacity, &node.ingress_queue.size())
         } else {
             write!(
                     f,
@@ -51,7 +52,7 @@ pub fn node_fmt_with_name(node: &Node, f: &mut fmt::Formatter<'_>, name: &str) -
                     &node.generation_rate,
                     node.plugin.as_ref().unwrap(),
                     &node.capacity,
-                    &node.queue.size()
+                    &node.ingress_queue.size()
                 )
         }
     }
@@ -65,14 +66,11 @@ impl fmt::Display for Node {
 
 impl SimElement for Node {
     fn tick(&mut self, tick: u64) -> Vec<Rpc> {
-        let mut outgoing_rpcs: Vec<Rpc> = vec![];
-        for _ in 0..min(
-            self.queue.size() + (self.generation_rate as usize),
-            self.egress_rate as usize,
-        ) {
+        for _ in 0..self.generation_rate as usize {
+            let mut queued_rpcs: Vec<Rpc> = vec![];
             // Dequeue an RPC, or generate one
             let mut rpc: Rpc;
-            if let Some(deq) = self.dequeue(tick) {
+            if let Some(deq) = self.dequeue_ingress(tick) {
                 rpc = deq;
             } else {
                 rpc = Rpc::new_rpc(&tick.to_string());
@@ -86,10 +84,18 @@ impl SimElement for Node {
 
             // Pass the RPCs we have through the plugin
             for rpc in new_rpcs {
-                self.pass_through_plugin(rpc, &mut outgoing_rpcs, tick, "egress");
+                self.pass_through_plugin(rpc, &mut queued_rpcs, tick, "egress");
+            }
+            for outgoing_rpc in &queued_rpcs {
+                self.enqueue_egress(outgoing_rpc.clone())
             }
         }
-        outgoing_rpcs
+        let max_output = min(self.egress_queue.size(), self.egress_rate as usize);
+        let mut outbound_rpcs: Vec<Rpc> = vec![];
+        for _ in 0..max_output {
+            outbound_rpcs.push(self.dequeue_egress().unwrap())
+        }
+        outbound_rpcs
     }
 
     // once the RPC is received, the plugin executes, the rpc gets a new destination,
@@ -97,11 +103,11 @@ impl SimElement for Node {
     // placed in the outbound queue
     fn recv(&mut self, rpc: Rpc, tick: u64) {
         // drop packets you cannot accept
-        if (self.queue.size() as u32) < self.capacity {
+        if ((self.ingress_queue.size() + self.egress_queue.size()) as u32) < self.capacity {
             let mut inbound_rpcs: Vec<Rpc> = vec![];
             self.pass_through_plugin(rpc, &mut inbound_rpcs, tick, "ingress");
             for inbound_rpc in inbound_rpcs {
-                self.enqueue(inbound_rpc, tick);
+                self.enqueue_ingress(inbound_rpc, tick);
             }
         }
     }
@@ -158,7 +164,8 @@ impl Node {
             created_plugin = Some(unwrapped_plugin);
         }
         Node {
-            queue: queue![],
+            ingress_queue: queue![],
+            egress_queue: queue![],
             id: id.to_string(),
             capacity,
             egress_rate,
@@ -192,14 +199,24 @@ impl Node {
         }
     }
 
-    pub fn enqueue(&mut self, x: Rpc, _now: u64) {
-        let _res = self.queue.add(x);
+    pub fn enqueue_ingress(&mut self, x: Rpc, _now: u64) {
+        let _res = self.ingress_queue.add(x);
     }
-    pub fn dequeue(&mut self, _now: u64) -> Option<Rpc> {
-        if self.queue.size() == 0 {
+    pub fn dequeue_ingress(&mut self, _now: u64) -> Option<Rpc> {
+        if self.ingress_queue.size() == 0 {
             return None;
         } else {
-            return Some(self.queue.remove().unwrap());
+            return Some(self.ingress_queue.remove().unwrap());
+        }
+    }
+    pub fn enqueue_egress(&mut self, x: Rpc) {
+        let _res = self.egress_queue.add(x);
+    }
+    pub fn dequeue_egress(&mut self) -> Option<Rpc> {
+        if self.egress_queue.size() == 0 {
+            return None;
+        } else {
+            return Some(self.egress_queue.remove().unwrap());
         }
     }
 }
@@ -222,11 +239,11 @@ mod tests {
         assert!(node.egress_rate == 1);
         node.recv(Rpc::new_rpc("0"), 0);
         node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.queue.size() == 2);
+        assert!(node.ingress_queue.size() == 2);
         node.recv(Rpc::new_rpc("0"), 0);
-        assert!(node.queue.size() == 2);
+        assert!(node.ingress_queue.size() == 2);
         node.tick(0);
-        assert!(node.queue.size() == 1);
+        assert!(node.ingress_queue.size() == 1);
     }
 
     #[test]

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -74,7 +74,7 @@ impl SimElement for Node {
             if let Some(deq) = self.dequeue_ingress(tick) {
                 rpc = deq;
             } else {
-                rpc = Rpc::new_rpc(&tick.to_string());
+                rpc = Rpc::new(&tick.to_string());
                 rpc.headers
                     .insert("direction".to_string(), "request".to_string());
             }
@@ -240,8 +240,8 @@ mod tests {
 
         assert!(node.capacity == 2);
         assert!(node.egress_rate == 1);
-        node.recv(Rpc::new_rpc("0"), 0);
-        node.recv(Rpc::new_rpc("0"), 0);
+        node.recv(Rpc::new("0"), 0);
+        node.recv(Rpc::new("0"), 0);
         queue_size = node.ingress_queue.size();
         assert!(
             node.ingress_queue.size() == 2,

--- a/libs/sim/node.rs
+++ b/libs/sim/node.rs
@@ -22,7 +22,7 @@ pub struct Node {
 }
 
 pub trait NodeTraits {
-    fn process_rpc(&self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>);
+    fn process_rpc(&mut self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>);
 }
 
 pub fn node_fmt_with_name(node: &Node, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
@@ -122,7 +122,7 @@ impl SimElement for Node {
 }
 
 impl NodeTraits for Node {
-    fn process_rpc(&self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
+    fn process_rpc(&mut self, rpc: &mut Rpc, new_rpcs: &mut Vec<Rpc>) {
         // Set yourself as the source
         rpc.headers.insert("src".to_string(), self.id.to_string());
 

--- a/libs/sim/plugin_wrapper.rs
+++ b/libs/sim/plugin_wrapper.rs
@@ -153,7 +153,7 @@ mod tests {
         cargo_dir.push("../../target/debug/libfilter_example");
         let library_str = cargo_dir.to_str().unwrap();
         let plugin = PluginWrapper::new("0", library_str);
-        let rpc = &Rpc::new_rpc("55");
+        let rpc = &Rpc::new("55");
         let rpc_data = &plugin.execute(rpc)[0].data;
         assert!(rpc_data == &"55".to_string());
     }
@@ -167,7 +167,7 @@ mod tests {
         let plugin2 = PluginWrapper::new("1", library_str);
         let plugin3 = PluginWrapper::new("2", library_str);
         let plugin4 = PluginWrapper::new("3", library_str);
-        let ret1: &Rpc = &plugin1.execute(&Rpc::new_rpc("5"))[0];
+        let ret1: &Rpc = &plugin1.execute(&Rpc::new("5"))[0];
         let ret2: &Rpc = &plugin2.execute(&ret1)[0];
         let ret3: &Rpc = &plugin3.execute(&ret2)[0];
         let ret4: &Rpc = &plugin4.execute(&ret3)[0];

--- a/libs/sim/storage.rs
+++ b/libs/sim/storage.rs
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn test_query_storage() {
         let mut storage = Storage::new("storage");
-        let mut rpc = Rpc::new_rpc("0");
+        let mut rpc = Rpc::new("0");
         rpc.headers
             .insert("dest".to_string(), "storage".to_string());
         storage.recv(rpc, 0);


### PR DESCRIPTION
This implements productpage only sending back one RPC when it receives responses from a reviews node and the details node.