### PR TITLE
Expand shamir algorithm

### DIFF
--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -224,14 +224,21 @@ pub fn find_root(graph: &Graph<(String, HashMap<String, String>), String>) -> No
     panic!("no root found");
 }
 
-pub fn has_property_subset(property_set_1: &HashMap<String,String>,
-                           property_set_2: &HashMap<String,String>)
-                           -> bool {
-
+pub fn has_property_subset(
+    property_set_1: &HashMap<String, String>,
+    property_set_2: &HashMap<String, String>,
+) -> bool {
     for key in property_set_2.keys() {
-        if !property_set_1.contains_key(key) { return false; }
-        print!("property 1 value is : {:?} and property 2 value is :{:?}", property_set_1[key], property_set_2[key]);
-        if property_set_1[key] != property_set_2[key] { return false; }
+        if !property_set_1.contains_key(key) {
+            return false;
+        }
+        print!(
+            "property 1 value is : {:?} and property 2 value is :{:?}",
+            property_set_1[key], property_set_2[key]
+        );
+        if property_set_1[key] != property_set_2[key] {
+            return false;
+        }
     }
     return true;
 }

--- a/libs/graph_utils/src/graph_utils.rs
+++ b/libs/graph_utils/src/graph_utils.rs
@@ -224,6 +224,18 @@ pub fn find_root(graph: &Graph<(String, HashMap<String, String>), String>) -> No
     panic!("no root found");
 }
 
+pub fn has_property_subset(property_set_1: &HashMap<String,String>,
+                           property_set_2: &HashMap<String,String>)
+                           -> bool {
+
+    for key in property_set_2.keys() {
+        if !property_set_1.contains_key(key) { return false; }
+        print!("property 1 value is : {:?} and property 2 value is :{:?}", property_set_1[key], property_set_2[key]);
+        if property_set_1[key] != property_set_2[key] { return false; }
+    }
+    return true;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/graph_utils/src/iso.rs
+++ b/libs/graph_utils/src/iso.rs
@@ -212,13 +212,33 @@ fn get_mapping_from_set_s(
     root_in_g: &NodeIndex,
 ) -> Vec<(NodeIndex, NodeIndex)> {
     let root_h = find_root(graph_h);
-    let mut to_return = set_s[&(*root_in_g, root_h)][&root_h]
-        .as_ref()
-        .unwrap()
-        .to_vec();
-    to_return.push((root_h, *root_in_g));
+    let mut to_return = Vec::new();
+    let mut set_to_find_mapping = vec![(root_h, *root_in_g)];
+    print_set_s(graph_g, graph_h, set_s);
+    while !set_to_find_mapping.is_empty() {
+        let key = set_to_find_mapping.pop().unwrap();
+        to_return.push(key);
+
+        print!(
+            "key is now {:?} {:?}\n\n\n",
+            graph_h.node_weight(key.0).unwrap().0,
+            graph_g.node_weight(key.1).unwrap().0
+        );
+        if set_s[&(key.1, key.0)].contains_key(&key.0) {
+            for map in set_s[&(key.1, key.0)][&key.0].as_ref() {
+                for mapping in map {
+                    if !to_return.contains(&(mapping.1, mapping.0)) {
+                        to_return.push((mapping.1, mapping.0));
+                        set_to_find_mapping.push(*mapping);
+                    }
+                }
+            }
+        }
+    }
+    print_set_s(graph_g, graph_h, set_s);
     return to_return;
 }
+
 pub fn find_mapping_shamir_centralized(
     graph_g: &Graph<(String, HashMap<String, String>), String>,
     graph_h: &Graph<(String, HashMap<String, String>), String>,

--- a/libs/graph_utils/src/iso.rs
+++ b/libs/graph_utils/src/iso.rs
@@ -86,18 +86,6 @@ fn max_matching(
         }
     }
     let (cost, paths) = graph_builder.mcmf();
-    if graph_h.node_weight(u_null).unwrap().0 == "b" {
-        print!("hellooooooo\n\n cost is {:?}", cost); print_set_s(graph_g, graph_h, set_s); 
-        print!("set x: ");
-        for node in set_x {
-            print!("printing x set");
-            print!("{:?} ", graph_h.node_weight(*node));
-        }
-        print!("\nset y: ");
-        for node in set_y {
-            print!("{:?} ", graph_g.node_weight(*node));
-        }
-    }
     let mut matching = Vec::new();
     for path in paths {
         // path is source + u_vertex + v_vertex + sink
@@ -129,13 +117,9 @@ fn find_mapping_shamir_centralized_inner_loop(
     let root_h = find_root(&graph_h);
     let v_neighbors: Vec<NodeIndex> = graph_g.neighbors_undirected(v).collect();
     for u in graph_h.node_indices() {
-        if graph_g.node_weight(v).unwrap().0 == "reviews-v1" {
-            print!("u is {:?} ", graph_h.node_weight(u).unwrap().0);
-        }
         let u_neighbors: Vec<NodeIndex> = graph_h.neighbors_undirected(u).collect();
         // all vertices of degree at most t+1
         if u_neighbors.len() > v_neighbors.len() + 1 {
-            println!("continu9ijn");
             continue;
         }
 
@@ -146,13 +130,8 @@ fn find_mapping_shamir_centralized_inner_loop(
                                          graph_h,
                                          set_s,
                                          u);
-        if graph_h.node_weight(u).unwrap().0 == "a" && graph_g.node_weight(v).unwrap().0 == "reviews-v1" {
-            println!("cost is {:?}", cost);
-            println!("u neighbors len is {:?}", u_neighbors.len())
-        }
         if cost == u_neighbors.len() as i32 {
                 if set_s[&(v,u)].contains_key(&u) {
-                    print!("hello\n\n\n\n\n");
                 } else {
                     set_s.get_mut(&(v, u)).unwrap().insert(u, Some(path));
                 }
@@ -170,7 +149,6 @@ fn find_mapping_shamir_centralized_inner_loop(
                                              u);
             if cost == new_x_set.len() as i32 {
                 if set_s[&(v,u)].contains_key(&vertex_id) {
-                    print!("hello\n\n\n\n\n");
                 } else {
                     set_s.get_mut(&(v, u)).unwrap().insert(vertex_id, Some(path));
                 }
@@ -182,6 +160,7 @@ fn find_mapping_shamir_centralized_inner_loop(
         if set_s[&(v, root_h)].contains_key(&root_h) {
             if has_property_subset(&graph_g.node_weight(v).unwrap().1,
                                    &graph_h.node_weight(root_h).unwrap().1) {
+                print_set_s(graph_g, graph_h, set_s);
                 return (true, Some(v));
             }
         }
@@ -216,29 +195,9 @@ fn get_mapping_from_set_s(
     root_in_g: &NodeIndex,
 ) -> Vec<(NodeIndex, NodeIndex)> {
     let root_h = find_root(graph_h);
-    /*
-    print_set_s(graph_g, graph_h, set_s);
-
-    print!("root in g label is {:?}\n", graph_g.node_weight(*root_in_g).unwrap());
-    print!("root in h label is {:?}\n", graph_h.node_weight(root_h).unwrap());
     let mut to_return = set_s[&(*root_in_g, root_h)][&root_h].as_ref().unwrap().to_vec();
-    for mapping in &to_return {
-        print!("I am mapping {:?} to {:?}\n", graph_h.node_weight(mapping.0).unwrap(), graph_g.node_weight(mapping.1).unwrap());
-    }
-    let mut to_return = set_s[&(*root_in_g, root_h)][&root_h].as_ref().unwrap().to_vec();
-    for mapping in &to_return {
-        print!("I am mapping {:?} to {:?}\n", graph_h.node_weight(mapping.0).unwrap(), graph_g.node_weight(mapping.1).unwrap());
-    }
-    /*
-    for mapping in &to_return {
-        let new_mapping = set_s[mapping]; //[&mapping.1].as_ref().unwrap().to_vec();
-        for new_m in new_mapping {
-            print!("I am mapping {:?} to {:?}\n", graph_h.node_weight(new_m.0).unwrap(), graph_g.node_weight(new_m.1).unwrap());
-        }
-    }
-    */
-    */
-    return Vec::new();
+    to_return.push((root_h, *root_in_g));
+    return to_return;
 
 }
 pub fn find_mapping_shamir_centralized(


### PR DESCRIPTION
This expands the Shamir algorithm in two ways:
1. It now takes into account properties, and only matches nodes if they contain all of the target properties.
2. It returns a mapping instead of true/false.