### PR TITLE
changed response size to request size

### DIFF
--- a/libs/sim/plugin_wrapper.rs
+++ b/libs/sim/plugin_wrapper.rs
@@ -88,6 +88,7 @@ impl PluginWrapper {
             String::from("node.metadata.WORKLOAD_NAME"),
             id_without_plugin,
         );
+        envoy_properties.insert(String::from("request.total_size"), "1".to_string());
         envoy_properties.insert(String::from("response.total_size"), "1".to_string());
         envoy_properties.insert(String::from("response.code"), "200".to_string());
         let new_filter = unsafe {


### PR DESCRIPTION
This is a really small edit to change the envoy properties that filters are initialized with.  It wouldn't be its own pull request, except to do integration tests for request_size_avg, etc, we need this to change.